### PR TITLE
Add workspace deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ When starting a conversation, the CLI:
 2. Optionally stashes dirty changes (`--stash`).
 3. Resolves a base ref (`origin/<defaultBranch>` if present, else the local default branch).
 4. Creates a branch named `conv/<conversationId>` at the base SHA.
-5. Adds a git worktree at `~/.maestro/workspaces/<conversationId>`.
+5. Adds a git worktree at `~/.maestro/workspaces/<project>--<title>--<hash>`.
 
 This produces isolated working directories per conversation while keeping the main repo clean.
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -12,6 +12,7 @@ import {
 import {
   appendEventEntry,
   appendTranscriptEntry,
+  deleteConversation,
   findProject,
   listConversations,
   listProjects,
@@ -30,8 +31,10 @@ import {
 } from "@maestro/storage";
 import {
   assertGitRepo,
+  deleteBranch,
   getRepoDisplayName,
   prepareWorkspace,
+  removeWorktree,
   resolveRepoRoot
 } from "@maestro/git";
 import { DirectSDKClient } from "@maestro/opencode";
@@ -227,6 +230,30 @@ program
       console.log(`Branch: ${conversation.branch}`);
       console.log(`Base: ${conversation.baseSha} (${conversation.baseRef})`);
       console.log(`Session: ${session.id}`);
+    } catch (error) {
+      exitWithError(error);
+    }
+  });
+
+const workspaceCommand = program.command("workspace").description("Workspace commands");
+
+workspaceCommand
+  .command("delete")
+  .argument("<conversationId>", "Conversation id")
+  .option("--confirm", "Confirm workspace deletion")
+  .description("Delete a workspace and its data")
+  .action(async (conversationId, options) => {
+    try {
+      if (!options.confirm) {
+        throw new Error("Workspace deletion requires --confirm.");
+      }
+      const repoRoot = await getRepoRootFromCwd();
+      const conversation = await readConversation(repoRoot, conversationId);
+      const project = await readProjectById(repoRoot, conversation.projectId);
+      await removeWorktree(project.repoPath, conversation.workspacePath);
+      await deleteBranch(project.repoPath, conversation.branch);
+      await deleteConversation(project.repoPath, conversation.id);
+      console.log(`Deleted workspace ${conversation.id}.`);
     } catch (error) {
       exitWithError(error);
     }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -173,6 +173,8 @@ program
       const workspace = await prepareWorkspace({
         repoRoot: project.repoPath,
         conversationId,
+        projectName: project.name,
+        conversationTitle: options.title,
         defaultBranch: project.defaultBranch,
         fromRef: options.from,
         stash: options.stash

--- a/apps/cli/src/server.ts
+++ b/apps/cli/src/server.ts
@@ -13,6 +13,7 @@ import {
   nowIso
 } from "@maestro/core";
 import {
+  deleteConversation,
   getMaestroPaths,
   listConversations,
   listProjects,
@@ -27,7 +28,13 @@ import {
   writeProject,
   writeSession
 } from "@maestro/storage";
-import { getRepoDisplayName, prepareWorkspace, resolveRepoRoot } from "@maestro/git";
+import {
+  deleteBranch,
+  getRepoDisplayName,
+  prepareWorkspace,
+  removeWorktree,
+  resolveRepoRoot
+} from "@maestro/git";
 
 type ServerOptions = {
   port: number;
@@ -204,7 +211,7 @@ const handleApi = async (req: IncomingMessage, res: ServerResponse, repoRoot: st
   const url = new URL(req.url, "http://localhost");
   const segments = parseSegments(url.pathname);
 
-  if (req.method !== "GET" && req.method !== "POST") {
+  if (req.method !== "GET" && req.method !== "POST" && req.method !== "DELETE") {
     sendJson(res, 405, { error: "Method Not Allowed" });
     return;
   }
@@ -418,43 +425,69 @@ const handleApi = async (req: IncomingMessage, res: ServerResponse, repoRoot: st
     }
   }
 
-  if (segments.length === 2 && segments[1] === "health") {
+  if (req.method === "GET" && segments.length === 2 && segments[1] === "health") {
     sendJson(res, 200, { ok: true });
     return;
   }
 
-  if (segments.length === 2 && segments[1] === "current") {
+  if (req.method === "GET" && segments.length === 2 && segments[1] === "current") {
     const current = await readCurrentContext(requestRepoRoot);
     sendJson(res, 200, current);
     return;
   }
 
-  if (segments.length === 2 && segments[1] === "projects") {
+  if (req.method === "GET" && segments.length === 2 && segments[1] === "projects") {
     const includeAll = url.searchParams.get("all") === "1" || url.searchParams.get("all") === "true";
     const projects = await listProjects(requestRepoRoot, { includeAll });
     sendJson(res, 200, projects);
     return;
   }
 
-  if (segments.length === 2 && segments[1] === "conversations") {
+  if (req.method === "GET" && segments.length === 2 && segments[1] === "conversations") {
     const conversations = await listConversations(requestRepoRoot);
     sendJson(res, 200, conversations);
     return;
   }
 
-  if (segments.length === 3 && segments[1] === "conversations") {
+  if (req.method === "GET" && segments.length === 3 && segments[1] === "conversations") {
     const conversation = await readConversation(requestRepoRoot, segments[2]);
     sendJson(res, 200, conversation);
     return;
   }
 
-  if (segments.length === 4 && segments[1] === "conversations" && segments[3] === "sessions") {
+  if (req.method === "DELETE" && segments.length === 3 && segments[1] === "conversations") {
+    const confirm = url.searchParams.get("confirm");
+    if (confirm !== "true" && confirm !== "1") {
+      sendBadRequest(res, "Deletion requires confirm=true.");
+      return;
+    }
+    try {
+      const conversation = await readConversation(requestRepoRoot, segments[2]);
+      const project = await readProjectById(requestRepoRoot, conversation.projectId);
+      await removeWorktree(project.repoPath, conversation.workspacePath);
+      await deleteBranch(project.repoPath, conversation.branch);
+      await deleteConversation(project.repoPath, conversation.id);
+      sendJson(res, 200, { ok: true });
+      return;
+    } catch (error) {
+      sendError(res, error);
+      return;
+    }
+  }
+
+  if (
+    req.method === "GET" &&
+    segments.length === 4 &&
+    segments[1] === "conversations" &&
+    segments[3] === "sessions"
+  ) {
     const sessions = await listSessions(requestRepoRoot, segments[2]);
     sendJson(res, 200, sessions);
     return;
   }
 
   if (
+    req.method === "GET" &&
     segments.length === 5 &&
     segments[1] === "conversations" &&
     segments[3] === "sessions"
@@ -465,6 +498,7 @@ const handleApi = async (req: IncomingMessage, res: ServerResponse, repoRoot: st
   }
 
   if (
+    req.method === "GET" &&
     segments.length === 6 &&
     segments[1] === "conversations" &&
     segments[3] === "sessions" &&
@@ -476,6 +510,7 @@ const handleApi = async (req: IncomingMessage, res: ServerResponse, repoRoot: st
   }
 
   if (
+    req.method === "GET" &&
     segments.length === 6 &&
     segments[1] === "conversations" &&
     segments[3] === "sessions" &&

--- a/apps/cli/src/server.ts
+++ b/apps/cli/src/server.ts
@@ -358,6 +358,8 @@ const handleApi = async (req: IncomingMessage, res: ServerResponse, repoRoot: st
       const workspace = await prepareWorkspace({
         repoRoot: project.repoPath,
         conversationId,
+        projectName: project.name,
+        conversationTitle: body.title?.trim() || undefined,
         defaultBranch: project.defaultBranch,
         fromRef: body.fromRef?.trim() || undefined,
         stash: body.stash ?? false

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -114,6 +114,8 @@ const App = () => {
   const [projectIconDraft, setProjectIconDraft] = React.useState("")
   const [isUpdatingProjectIcon, setIsUpdatingProjectIcon] = React.useState(false)
   const [projectIconError, setProjectIconError] = React.useState<string | null>(null)
+  const [isDeletingWorkspace, setIsDeletingWorkspace] = React.useState(false)
+  const [deleteWorkspaceError, setDeleteWorkspaceError] = React.useState<string | null>(null)
 
   const loadProjects = React.useCallback(async () => {
     setIsLoading(true)
@@ -254,6 +256,10 @@ const App = () => {
     setProjectIconDraft(selectedProject?.icon ?? "")
     setProjectIconError(null)
   }, [selectedProject])
+
+  React.useEffect(() => {
+    setDeleteWorkspaceError(null)
+  }, [selectedWorkspaceId])
 
   const handleSelectProjectsView = () => {
     setIsProjectsView(true)
@@ -467,6 +473,50 @@ const App = () => {
     }
   }
 
+  const handleDeleteWorkspace = async () => {
+    if (!selectedProject || !selectedWorkspace) {
+      return
+    }
+    const workspaceLabel = selectedWorkspace.name || selectedWorkspace.id
+    const confirmed = window.confirm(
+      `Delete workspace "${workspaceLabel}"? This removes the worktree and all sessions.`
+    )
+    if (!confirmed) {
+      return
+    }
+    setIsDeletingWorkspace(true)
+    setDeleteWorkspaceError(null)
+    try {
+      const response = await fetch(
+        `/api/conversations/${selectedWorkspace.id}?confirm=true`,
+        {
+          method: "DELETE",
+        }
+      )
+      if (!response.ok) {
+        let message = "Failed to delete workspace."
+        try {
+          const payload = (await response.json()) as { error?: string }
+          if (payload.error) {
+            message = payload.error
+          }
+        } catch {
+          // Ignore parsing errors
+        }
+        throw new Error(message)
+      }
+      setSelectedWorkspaceId(null)
+      setSelectedChatId(null)
+      await loadProjects()
+    } catch (err) {
+      setDeleteWorkspaceError(
+        err instanceof Error ? err.message : "Failed to delete workspace."
+      )
+    } finally {
+      setIsDeletingWorkspace(false)
+    }
+  }
+
   const formatDate = (value?: string) => {
     if (!value) {
       return "Unknown"
@@ -642,6 +692,23 @@ const App = () => {
             <div className="mt-2 max-w-2xl text-sm text-muted-foreground">
               {viewDescription}
             </div>
+            {isWorkspaceView ? (
+              <div className="mt-4 flex flex-wrap items-center gap-3">
+                <Button
+                  type="button"
+                  variant="destructive"
+                  onClick={handleDeleteWorkspace}
+                  disabled={isDeletingWorkspace}
+                >
+                  {isDeletingWorkspace ? "Deleting workspace..." : "Delete workspace"}
+                </Button>
+                {deleteWorkspaceError ? (
+                  <div className="rounded-md border border-destructive/50 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+                    {deleteWorkspaceError}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
           </div>
           {isProjectsView ? (
             <div className="grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -11,6 +11,7 @@
     }
   },
   "scripts": {
-    "build": "bun tsc -p tsconfig.json"
+    "build": "bun tsc -p tsconfig.json",
+    "test": "bun test"
   }
 }

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -3,10 +3,10 @@
   "version": "0.0.0",
   "type": "module",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.d.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/git/src/index.d.ts
+++ b/packages/git/src/index.d.ts
@@ -23,6 +23,8 @@ export declare const stashChanges: (repoRoot: string, conversationId: string) =>
 export declare const prepareWorkspace: (options: {
     repoRoot: string;
     conversationId: string;
+    projectName: string;
+    conversationTitle?: string;
     defaultBranch: string;
     fromRef?: string;
     stash?: boolean;

--- a/packages/git/src/index.d.ts
+++ b/packages/git/src/index.d.ts
@@ -19,6 +19,8 @@ export declare const fetchAll: (repoRoot: string) => Promise<void>;
 export declare const resolveRef: (repoRoot: string, ref: string) => Promise<string>;
 export declare const createBranch: (repoRoot: string, branch: string, sha: string) => Promise<void>;
 export declare const createWorktree: (repoRoot: string, worktreePath: string, branch: string) => Promise<void>;
+export declare const removeWorktree: (repoRoot: string, worktreePath: string) => Promise<void>;
+export declare const deleteBranch: (repoRoot: string, branch: string) => Promise<void>;
 export declare const stashChanges: (repoRoot: string, conversationId: string) => Promise<string>;
 export declare const prepareWorkspace: (options: {
     repoRoot: string;

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -19,6 +19,39 @@ export interface WorkspaceResult {
   stashRef?: string;
 }
 
+const slugify = (value: string, fallback: string): string => {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+  return normalized || fallback;
+};
+
+const truncateSlug = (value: string, maxLength: number): string => {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return value.slice(0, maxLength).replace(/-+$/g, "");
+};
+
+const getConversationHash = (conversationId: string): string => {
+  const parts = conversationId.split("_");
+  return parts.length > 1 ? parts[1] : conversationId;
+};
+
+const buildWorkspaceDirName = (
+  projectName: string,
+  conversationTitle: string | undefined,
+  conversationId: string
+): string => {
+  const projectSlug = truncateSlug(slugify(projectName, "project"), 24);
+  const titleSlug = truncateSlug(slugify(conversationTitle ?? "untitled", "untitled"), 32);
+  const hash = getConversationHash(conversationId);
+  return `${projectSlug}--${titleSlug}--${hash}`;
+};
+
 const runGit = async (repoRoot: string, args: string[]): Promise<GitRunResult> => {
   const { stdout, stderr } = await execFileAsync("git", ["-C", repoRoot, ...args]);
   return { stdout: stdout.trim(), stderr: stderr.trim() };
@@ -141,11 +174,21 @@ export const stashChanges = async (
 export const prepareWorkspace = async (options: {
   repoRoot: string;
   conversationId: string;
+  projectName: string;
+  conversationTitle?: string;
   defaultBranch: string;
   fromRef?: string;
   stash?: boolean;
 }): Promise<WorkspaceResult> => {
-  const { repoRoot, conversationId, defaultBranch, fromRef, stash } = options;
+  const {
+    repoRoot,
+    conversationId,
+    projectName,
+    conversationTitle,
+    defaultBranch,
+    fromRef,
+    stash
+  } = options;
   const dirty = await isDirty(repoRoot);
   let stashRef: string | undefined;
   if (dirty) {
@@ -157,6 +200,7 @@ export const prepareWorkspace = async (options: {
 
   let baseRef = fromRef;
   if (!baseRef) {
+    await fetchAll(repoRoot);
     const remoteRef = `origin/${defaultBranch}`;
     baseRef = (await refExists(repoRoot, remoteRef)) ? remoteRef : defaultBranch;
   }
@@ -174,13 +218,8 @@ export const prepareWorkspace = async (options: {
 
   const branch = `conv/${conversationId}`;
   await createBranch(repoRoot, branch, baseSha);
-  const repoSlug = await getRepoSlug(repoRoot);
-  const worktreePath = path.join(
-    os.homedir(),
-    ".maestro",
-    "workspaces",
-    `${repoSlug}--${conversationId}`
-  );
+  const workspaceDirName = buildWorkspaceDirName(projectName, conversationTitle, conversationId);
+  const worktreePath = path.join(os.homedir(), ".maestro", "workspaces", workspaceDirName);
   await createWorktree(repoRoot, worktreePath, branch);
 
   return { branch, worktreePath, baseRef, baseSha, stashRef };

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -156,6 +156,26 @@ export const createWorktree = async (
   await runGit(repoRoot, ["worktree", "add", worktreePath, branch]);
 };
 
+export const removeWorktree = async (repoRoot: string, worktreePath: string): Promise<void> => {
+  try {
+    const stat = await fs.stat(worktreePath);
+    if (!stat.isDirectory()) {
+      return;
+    }
+  } catch {
+    await runGit(repoRoot, ["worktree", "prune"]);
+    return;
+  }
+  await runGit(repoRoot, ["worktree", "remove", "--force", worktreePath]);
+};
+
+export const deleteBranch = async (repoRoot: string, branch: string): Promise<void> => {
+  if (!(await refExists(repoRoot, branch))) {
+    return;
+  }
+  await runGit(repoRoot, ["branch", "-D", branch]);
+};
+
 export const stashChanges = async (
   repoRoot: string,
   conversationId: string

--- a/packages/git/test/prepareWorkspace.test.ts
+++ b/packages/git/test/prepareWorkspace.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { execFile } from "node:child_process";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { prepareWorkspace } from "../src/index";
+
+const execFileAsync = promisify(execFile);
+
+const runGit = async (repoRoot: string, args: string[]): Promise<string> => {
+  const { stdout } = await execFileAsync("git", ["-C", repoRoot, ...args]);
+  return stdout.trim();
+};
+
+const writeFile = async (filePath: string, contents: string): Promise<void> => {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, contents, "utf8");
+};
+
+const ensureDir = async (dirPath: string): Promise<void> => {
+  await fs.mkdir(dirPath, { recursive: true });
+};
+
+describe("prepareWorkspace", () => {
+  let tempRoot: string | undefined;
+  let originalHome: string | undefined;
+
+  afterEach(async () => {
+    if (originalHome) {
+      process.env.HOME = originalHome;
+    }
+    if (tempRoot) {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("uses latest origin/main when fromRef is unset", async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "maestro-git-"));
+    const homeDir = path.join(tempRoot, "home");
+    const remotePath = path.join(tempRoot, "remote.git");
+    const seedPath = path.join(tempRoot, "seed");
+    const clonePath = path.join(tempRoot, "clone");
+
+    await ensureDir(homeDir);
+    await runGit(tempRoot, ["init", "--bare", remotePath]);
+
+    await runGit(tempRoot, ["init", "-b", "main", seedPath]);
+    await runGit(seedPath, ["config", "user.email", "maestro@example.com"]);
+    await runGit(seedPath, ["config", "user.name", "Maestro Test"]);
+    await writeFile(path.join(seedPath, "README.md"), "initial\n");
+    await runGit(seedPath, ["add", "README.md"]);
+    await runGit(seedPath, ["commit", "-m", "initial"]);
+    await runGit(seedPath, ["remote", "add", "origin", remotePath]);
+    await runGit(seedPath, ["push", "-u", "origin", "main"]);
+
+    await runGit(tempRoot, ["clone", remotePath, clonePath]);
+
+    await writeFile(path.join(seedPath, "CHANGELOG.md"), "update\n");
+    await runGit(seedPath, ["add", "CHANGELOG.md"]);
+    await runGit(seedPath, ["commit", "-m", "update"]);
+    await runGit(seedPath, ["push"]);
+
+    const latestSha = await runGit(seedPath, ["rev-parse", "main"]);
+
+    originalHome = process.env.HOME;
+    process.env.HOME = homeDir;
+
+    const result = await prepareWorkspace({
+      repoRoot: clonePath,
+      conversationId: "c_test",
+      projectName: "demo",
+      defaultBranch: "main"
+    });
+
+    expect(result.baseRef).toBe("origin/main");
+    expect(result.baseSha).toBe(latestSha);
+  });
+});

--- a/packages/storage/src/index.d.ts
+++ b/packages/storage/src/index.d.ts
@@ -17,6 +17,7 @@ export declare const findProject: (repoRoot: string, nameOrId: string) => Promis
 export declare const writeConversation: (repoRoot: string, conversation: Conversation) => Promise<void>;
 export declare const readConversation: (repoRoot: string, conversationId: string) => Promise<Conversation>;
 export declare const listConversations: (repoRoot: string) => Promise<Conversation[]>;
+export declare const deleteConversation: (repoRoot: string, conversationId: string) => Promise<void>;
 export declare const writeSession: (repoRoot: string, conversationId: string, session: Session) => Promise<void>;
 export declare const readSession: (repoRoot: string, conversationId: string, sessionId: string) => Promise<Session>;
 export declare const listSessions: (repoRoot: string, conversationId: string) => Promise<Session[]>;

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -141,6 +141,16 @@ export const listConversations = async (repoRoot: string): Promise<Conversation[
   }
 };
 
+export const deleteConversation = async (repoRoot: string, conversationId: string): Promise<void> => {
+  const { conversationsDir } = getMaestroPaths(repoRoot);
+  const conversationDir = path.join(conversationsDir, conversationId);
+  await fs.rm(conversationDir, { recursive: true, force: true });
+  const current = await readCurrentContext(repoRoot);
+  if (current.conversationId === conversationId) {
+    await setCurrentContext(repoRoot, { projectId: current.projectId });
+  }
+};
+
 export const writeSession = async (
   repoRoot: string,
   conversationId: string,


### PR DESCRIPTION
## Summary
- revamp web app navigation with projects/workspaces/chats and project icon editing
- add API/CLI support for workspace naming, icon updates, and session titles
- add workspace deletion in CLI and web UI, removing worktree/branch and stored state

## Testing
- Not run (not requested)