### PR TITLE
feat: add dark mode support

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { Moon, Sun } from "lucide-react"
 
 import { AppSidebar } from "./components/app-sidebar"
 import {
@@ -27,6 +28,7 @@ import {
   SidebarRail,
   SidebarTrigger,
 } from "./components/ui/sidebar"
+import { useTheme } from "./hooks/use-theme"
 
 type GitProvider = "github" | "gitlab"
 
@@ -92,6 +94,7 @@ type Project = {
 }
 
 const App = () => {
+  const { theme, toggleTheme } = useTheme()
   const [projects, setProjects] = React.useState<Project[]>([])
   const [isLoading, setIsLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
@@ -798,6 +801,19 @@ const App = () => {
               ) : null}
             </BreadcrumbList>
           </Breadcrumb>
+          <div className="ml-auto flex items-center gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={toggleTheme}
+              aria-label="Toggle dark mode"
+              title="Toggle dark mode"
+            >
+              {theme === "dark" ? <Sun /> : <Moon />}
+              <span className="sr-only">Toggle dark mode</span>
+            </Button>
+          </div>
         </header>
         <div className="flex flex-1 flex-col gap-4 p-6">
           <div className="rounded-xl border bg-card p-6 shadow-sm">

--- a/apps/web/src/hooks/use-theme.tsx
+++ b/apps/web/src/hooks/use-theme.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { applyTheme, getPreferredTheme, storeTheme, type Theme } from "../lib/theme"
+
+export const useTheme = () => {
+  const [theme, setTheme] = React.useState<Theme>(() => getPreferredTheme())
+
+  React.useEffect(() => {
+    applyTheme(theme)
+  }, [theme])
+
+  const toggleTheme = React.useCallback(() => {
+    setTheme((prev) => {
+      const next = prev === "dark" ? "light" : "dark"
+      storeTheme(next)
+      return next
+    })
+  }, [])
+
+  return { theme, toggleTheme }
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -23,6 +23,28 @@
   --input: 214 20% 90%;
   --ring: 224 30% 12%;
   --radius: 8px;
+  color-scheme: light;
+}
+
+.dark {
+  --background: 224 35% 6%;
+  --foreground: 210 40% 98%;
+  --card: 224 35% 8%;
+  --card-foreground: 210 40% 98%;
+  --popover: 224 35% 8%;
+  --popover-foreground: 210 40% 98%;
+  --primary: 210 40% 98%;
+  --primary-foreground: 224 35% 6%;
+  --secondary: 220 26% 12%;
+  --secondary-foreground: 210 40% 98%;
+  --muted: 220 26% 12%;
+  --muted-foreground: 215 12% 72%;
+  --accent: 220 26% 12%;
+  --accent-foreground: 210 40% 98%;
+  --border: 220 26% 14%;
+  --input: 220 26% 14%;
+  --ring: 212 95% 70%;
+  color-scheme: dark;
 }
 
 * {

--- a/apps/web/src/lib/theme.ts
+++ b/apps/web/src/lib/theme.ts
@@ -1,0 +1,41 @@
+export type Theme = "light" | "dark"
+
+const STORAGE_KEY = "theme"
+
+export const getStoredTheme = (): Theme | null => {
+  if (typeof window === "undefined") {
+    return null
+  }
+  const stored = window.localStorage.getItem(STORAGE_KEY)
+  if (stored === "light" || stored === "dark") {
+    return stored
+  }
+  return null
+}
+
+export const getPreferredTheme = (): Theme => {
+  if (typeof window === "undefined") {
+    return "light"
+  }
+  const stored = getStoredTheme()
+  if (stored) {
+    return stored
+  }
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light"
+}
+
+export const applyTheme = (theme: Theme) => {
+  if (typeof document === "undefined") {
+    return
+  }
+  document.documentElement.classList.toggle("dark", theme === "dark")
+}
+
+export const storeTheme = (theme: Theme) => {
+  if (typeof window === "undefined") {
+    return
+  }
+  window.localStorage.setItem(STORAGE_KEY, theme)
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,6 +2,9 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import { applyTheme, getPreferredTheme } from "./lib/theme";
+
+applyTheme(getPreferredTheme());
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- add theme tokens for dark mode with deeper palette and color-scheme hints
- apply preferred theme on startup and persist toggle choice
- add a header toggle button to switch modes