### PR TITLE
feat: add settings page for tokens

### DIFF
--- a/apps/cli/src/server.ts
+++ b/apps/cli/src/server.ts
@@ -24,6 +24,7 @@ import {
   appendTranscriptEntry,
   readConversation,
   readCurrentContext,
+  readSettings,
   readProjectById,
   readSession,
   readTranscriptHistory,
@@ -32,6 +33,7 @@ import {
   updateSessionTimestamp,
   writeConversation,
   writeProject,
+  writeSettings,
   writeSession
 } from "@maestro/storage";
 import {
@@ -237,11 +239,22 @@ const buildGitHubApiBase = (host: string): string => {
   return `https://${host}/api/v3`;
 };
 
+const resolveGitHubToken = async (repoRoot: string): Promise<string | undefined> => {
+  const envToken = process.env.GITHUB_TOKEN?.trim();
+  if (envToken) {
+    return envToken;
+  }
+  const settings = await readSettings(repoRoot);
+  const stored = settings.githubToken?.trim();
+  return stored || undefined;
+};
+
 const buildGitLabApiBase = (host: string): string => {
   return `https://${host}/api/v4`;
 };
 
 const fetchGitHubPullRequests = async (
+  repoRoot: string,
   repoUrl: string,
   limit: number
 ): Promise<PullRequestInfo[]> => {
@@ -261,7 +274,7 @@ const fetchGitHubPullRequests = async (
     Accept: "application/vnd.github+json",
     "User-Agent": "Maestro"
   };
-  const token = process.env.GITHUB_TOKEN;
+  const token = await resolveGitHubToken(repoRoot);
   if (token) {
     headers.Authorization = `Bearer ${token}`;
   }
@@ -473,9 +486,50 @@ const handleApi = async (req: IncomingMessage, res: ServerResponse, repoRoot: st
   const url = new URL(req.url, "http://localhost");
   const segments = parseSegments(url.pathname);
 
-  if (req.method !== "GET" && req.method !== "POST" && req.method !== "DELETE") {
+  if (
+    req.method !== "GET" &&
+    req.method !== "POST" &&
+    req.method !== "DELETE" &&
+    req.method !== "PUT"
+  ) {
     sendJson(res, 405, { error: "Method Not Allowed" });
     return;
+  }
+
+  if (req.method === "GET" && segments.length === 2 && segments[1] === "settings") {
+    const settings = await readSettings(repoRoot);
+    sendJson(res, 200, settings);
+    return;
+  }
+
+  if (req.method === "PUT" && segments.length === 2 && segments[1] === "settings") {
+    try {
+      const body = await readJsonBody<{
+        githubToken?: string | null;
+        gotlandToken?: string | null;
+      }>(req);
+      const normalizeToken = (value?: string | null): string | undefined => {
+        if (typeof value !== "string") {
+          return undefined;
+        }
+        const trimmed = value.trim();
+        return trimmed.length ? trimmed : undefined;
+      };
+      const nextSettings = {
+        githubToken: normalizeToken(body.githubToken),
+        gotlandToken: normalizeToken(body.gotlandToken)
+      };
+      await writeSettings(repoRoot, nextSettings);
+      sendJson(res, 200, nextSettings);
+      return;
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        sendBadRequest(res, "Invalid JSON body.");
+        return;
+      }
+      sendError(res, error);
+      return;
+    }
   }
 
   if (req.method === "GET" && segments.length === 3 && segments[1] === "fs" && segments[2] === "root") {
@@ -720,7 +774,7 @@ const handleApi = async (req: IncomingMessage, res: ServerResponse, repoRoot: st
         : 10;
       const pullRequests =
         provider === "github"
-          ? await fetchGitHubPullRequests(repoUrl, limit)
+          ? await fetchGitHubPullRequests(requestRepoRoot, repoUrl, limit)
           : await fetchGitLabMergeRequests(repoUrl, limit);
       sendJson(res, 200, pullRequests);
       return;

--- a/apps/cli/src/server.ts
+++ b/apps/cli/src/server.ts
@@ -366,7 +366,11 @@ const fetchGitLabMergeRequests = async (
   }));
 };
 
-const mergeGitHubPullRequest = async (repoUrl: string, pullNumber: string): Promise<void> => {
+const mergeGitHubPullRequest = async (
+  repoRoot: string,
+  repoUrl: string,
+  pullNumber: string
+): Promise<void> => {
   const parsed = parseRepoUrl(repoUrl);
   if (!parsed) {
     throw new Error("Invalid GitHub repository URL.");
@@ -375,7 +379,7 @@ const mergeGitHubPullRequest = async (repoUrl: string, pullNumber: string): Prom
   if (!owner || !repo) {
     throw new Error("GitHub repository URL must include owner and repo.");
   }
-  const token = process.env.GITHUB_TOKEN;
+  const token = await resolveGitHubToken(repoRoot);
   if (!token) {
     throw new Error("GITHUB_TOKEN is required to merge GitHub pull requests.");
   }
@@ -908,7 +912,7 @@ const handleApi = async (req: IncomingMessage, res: ServerResponse, repoRoot: st
         return;
       }
       if (provider === "github") {
-        await mergeGitHubPullRequest(repoUrl, pullRequestId);
+        await mergeGitHubPullRequest(requestRepoRoot, repoUrl, pullRequestId);
       } else {
         await mergeGitLabMergeRequest(repoUrl, pullRequestId);
       }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,4 @@
 import * as React from "react"
-import { Moon, Sun } from "lucide-react"
 
 import { AppSidebar } from "./components/app-sidebar"
 import {
@@ -159,6 +158,7 @@ const App = () => {
   const [isLoading, setIsLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
   const [isProjectsView, setIsProjectsView] = React.useState(false)
+  const [isSettingsView, setIsSettingsView] = React.useState(false)
   const [selectedProjectId, setSelectedProjectId] = React.useState<string | null>(
     null
   )
@@ -206,6 +206,15 @@ const App = () => {
   const [openPullRequests, setOpenPullRequests] = React.useState<OpenPullRequest[]>([])
   const [isLoadingPullRequests, setIsLoadingPullRequests] = React.useState(false)
   const [pullRequestsError, setPullRequestsError] = React.useState<string | null>(null)
+  const [settingsForm, setSettingsForm] = React.useState({
+    githubToken: "",
+    gotlandToken: "",
+  })
+  const [settingsError, setSettingsError] = React.useState<string | null>(null)
+  const [settingsSavedMessage, setSettingsSavedMessage] = React.useState<string | null>(
+    null
+  )
+  const [isSavingSettings, setIsSavingSettings] = React.useState(false)
   const recentSessionsLimit = 6
 
   const loadProjects = React.useCallback(async () => {
@@ -294,9 +303,35 @@ const App = () => {
     }
   }, [])
 
+  const loadSettings = React.useCallback(async () => {
+    setSettingsError(null)
+    try {
+      const response = await fetch("/api/settings")
+      if (!response.ok) {
+        throw new Error("Failed to load settings.")
+      }
+      const payload = (await response.json()) as {
+        githubToken?: string
+        gotlandToken?: string
+      }
+      setSettingsForm({
+        githubToken: payload.githubToken ?? "",
+        gotlandToken: payload.gotlandToken ?? "",
+      })
+    } catch (err) {
+      setSettingsError(
+        err instanceof Error ? err.message : "Failed to load settings."
+      )
+    }
+  }, [])
+
   React.useEffect(() => {
     void loadProjects()
   }, [loadProjects])
+
+  React.useEffect(() => {
+    void loadSettings()
+  }, [loadSettings])
 
   React.useEffect(() => {
     if (!projects.length) {
@@ -598,13 +633,20 @@ const App = () => {
 
   const handleSelectProjectsView = () => {
     setIsProjectsView(true)
+    setIsSettingsView(false)
     setSelectedProjectId(null)
     setSelectedWorkspaceId(null)
     setSelectedChatId(null)
   }
 
+  const handleSelectSettingsView = () => {
+    setIsSettingsView(true)
+    setIsProjectsView(false)
+  }
+
   const handleSelectProject = (projectId: string) => {
     setIsProjectsView(false)
+    setIsSettingsView(false)
     setSelectedProjectId(projectId)
     setSelectedWorkspaceId(null)
     setSelectedChatId(null)
@@ -612,6 +654,7 @@ const App = () => {
 
   const handleSelectWorkspace = (projectId: string, workspaceId: string) => {
     setIsProjectsView(false)
+    setIsSettingsView(false)
     setSelectedProjectId(projectId)
     setSelectedWorkspaceId(workspaceId)
     setSelectedChatId(null)
@@ -623,6 +666,7 @@ const App = () => {
     chatId: string
   ) => {
     setIsProjectsView(false)
+    setIsSettingsView(false)
     setSelectedProjectId(projectId)
     setSelectedWorkspaceId(workspaceId)
     setSelectedChatId(chatId)
@@ -635,6 +679,14 @@ const App = () => {
     }
   }
 
+  const handleSettingsChange = (field: keyof typeof settingsForm) => {
+    return (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value
+      setSettingsForm((prev) => ({ ...prev, [field]: value }))
+      setSettingsSavedMessage(null)
+    }
+  }
+
   const handleWorkspaceFormChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value
     setWorkspaceForm({ title: value })
@@ -643,6 +695,50 @@ const App = () => {
   const handleSessionFormChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value
     setSessionForm({ title: value })
+  }
+
+  const handleSettingsSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setIsSavingSettings(true)
+    setSettingsError(null)
+    setSettingsSavedMessage(null)
+    try {
+      const response = await fetch("/api/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          githubToken: settingsForm.githubToken.trim() || null,
+          gotlandToken: settingsForm.gotlandToken.trim() || null,
+        }),
+      })
+      if (!response.ok) {
+        let message = "Failed to save settings."
+        try {
+          const payload = (await response.json()) as { error?: string }
+          if (payload.error) {
+            message = payload.error
+          }
+        } catch {
+          // Ignore parsing errors
+        }
+        throw new Error(message)
+      }
+      const payload = (await response.json()) as {
+        githubToken?: string
+        gotlandToken?: string
+      }
+      setSettingsForm({
+        githubToken: payload.githubToken ?? "",
+        gotlandToken: payload.gotlandToken ?? "",
+      })
+      setSettingsSavedMessage("Settings saved.")
+    } catch (err) {
+      setSettingsError(
+        err instanceof Error ? err.message : "Failed to save settings."
+      )
+    } finally {
+      setIsSavingSettings(false)
+    }
   }
 
   const handleSelectDirectory = async () => {
@@ -1119,41 +1215,52 @@ const App = () => {
   }
 
   const isProjectView = Boolean(
-    selectedProject && !selectedWorkspace && !selectedChat && !isProjectsView
+    !isSettingsView &&
+      selectedProject &&
+      !selectedWorkspace &&
+      !selectedChat &&
+      !isProjectsView
   )
-  const isWorkspaceView = Boolean(selectedWorkspace && !selectedChat)
-  const isChatView = Boolean(selectedChat)
+  const isWorkspaceView = Boolean(!isSettingsView && selectedWorkspace && !selectedChat)
+  const isChatView = Boolean(!isSettingsView && selectedChat)
   const isChatStreaming = chatStatus === "streaming"
   const projectIconValue = selectedProject?.icon?.trim() ?? ""
   const promptDisabled =
     isChatStreaming || !selectedWorkspace || !selectedChat || isTranscriptLoading
+  const nextThemeLabel = theme === "dark" ? "Light" : "Dark"
 
-  const viewLabel = isChatView
-    ? "Chat Session"
-    : isWorkspaceView
-      ? "Workspace"
-      : isProjectView
-        ? "Project"
-        : "Home"
-  const viewTitle = isProjectsView
-    ? "Home"
-    : selectedChat?.name ??
-      selectedWorkspace?.name ??
-      selectedProject?.name ??
-      (isLoading ? "Syncing projects" : "Choose a project")
-  const viewDescription = isProjectsView
-    ? "Home for your projects, new work, and recent workspaces."
-    : selectedChat
-      ? `Workspace in ${selectedWorkspace?.name ?? "workspace"}.`
-      : selectedWorkspace
-        ? "Workspace activity, members, and recent sessions."
-        : selectedProject
-          ? `Repo: ${selectedProject.repoUrl?.trim() || selectedProject.repoPath}`
-          : isLoading
-            ? "Fetching projects, workspaces, and sessions."
-            : error
-              ? error
-              : "Select a project to explore its workspaces."
+  const viewLabel = isSettingsView
+    ? "Settings"
+    : isChatView
+      ? "Chat Session"
+      : isWorkspaceView
+        ? "Workspace"
+        : isProjectView
+          ? "Project"
+          : "Home"
+  const viewTitle = isSettingsView
+    ? "Settings"
+    : isProjectsView
+      ? "Home"
+      : selectedChat?.name ??
+        selectedWorkspace?.name ??
+        selectedProject?.name ??
+        (isLoading ? "Syncing projects" : "Choose a project")
+  const viewDescription = isSettingsView
+    ? "Manage access tokens and appearance for Maestro."
+    : isProjectsView
+      ? "Home for your projects, new work, and recent workspaces."
+      : selectedChat
+        ? `Workspace in ${selectedWorkspace?.name ?? "workspace"}.`
+        : selectedWorkspace
+          ? "Workspace activity, members, and recent sessions."
+          : selectedProject
+            ? `Repo: ${selectedProject.repoUrl?.trim() || selectedProject.repoPath}`
+            : isLoading
+              ? "Fetching projects, workspaces, and sessions."
+              : error
+                ? error
+                : "Select a project to explore its workspaces."
 
   const secondaryTitle = isChatView
     ? "Workspace context"
@@ -1185,17 +1292,19 @@ const App = () => {
   const recentSessionsForView = isProjectView ? projectRecentSessions : recentSessions
   return (
     <SidebarProvider>
-      <AppSidebar
-        projects={projects}
-        isProjectsView={isProjectsView}
-        selectedProjectId={selectedProjectId}
-        selectedWorkspaceId={selectedWorkspaceId}
-        selectedChatId={selectedChatId}
-        onSelectProjects={handleSelectProjectsView}
-        onSelectProject={handleSelectProject}
-        onSelectWorkspace={handleSelectWorkspace}
-        onSelectChat={handleSelectChat}
-      />
+        <AppSidebar
+          projects={projects}
+          isProjectsView={isProjectsView}
+          isSettingsView={isSettingsView}
+          selectedProjectId={selectedProjectId}
+          selectedWorkspaceId={selectedWorkspaceId}
+          selectedChatId={selectedChatId}
+          onSelectProjects={handleSelectProjectsView}
+          onSelectSettings={handleSelectSettingsView}
+          onSelectProject={handleSelectProject}
+          onSelectWorkspace={handleSelectWorkspace}
+          onSelectChat={handleSelectChat}
+        />
       <SidebarRail />
       <SidebarInset>
         <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
@@ -1203,89 +1312,197 @@ const App = () => {
           <Separator orientation="vertical" className="mr-2 h-4" />
           <Breadcrumb>
             <BreadcrumbList>
-              <BreadcrumbItem>
-                {selectedProject ? (
-                  <BreadcrumbLink
-                    href="#"
-                    onClick={(event) => {
-                      event.preventDefault()
-                      handleSelectProjectsView()
-                    }}
-                  >
-                    Home
-                  </BreadcrumbLink>
-                ) : (
-                  <BreadcrumbPage>Home</BreadcrumbPage>
-                )}
-              </BreadcrumbItem>
-              {selectedProject && !isLoading ? (
+              {isSettingsView ? (
+                <BreadcrumbItem>
+                  <BreadcrumbPage>Settings</BreadcrumbPage>
+                </BreadcrumbItem>
+              ) : (
                 <>
-                  <BreadcrumbSeparator />
                   <BreadcrumbItem>
-                    {selectedWorkspace || selectedChat ? (
+                    {selectedProject ? (
                       <BreadcrumbLink
                         href="#"
                         onClick={(event) => {
                           event.preventDefault()
-                          handleSelectProject(selectedProject.id)
+                          handleSelectProjectsView()
                         }}
                       >
-                        {selectedProject.name}
+                        Home
                       </BreadcrumbLink>
                     ) : (
-                      <BreadcrumbPage>{selectedProject.name}</BreadcrumbPage>
+                      <BreadcrumbPage>Home</BreadcrumbPage>
                     )}
                   </BreadcrumbItem>
+                  {selectedProject && !isLoading ? (
+                    <>
+                      <BreadcrumbSeparator />
+                      <BreadcrumbItem>
+                        {selectedWorkspace || selectedChat ? (
+                          <BreadcrumbLink
+                            href="#"
+                            onClick={(event) => {
+                              event.preventDefault()
+                              handleSelectProject(selectedProject.id)
+                            }}
+                          >
+                            {selectedProject.name}
+                          </BreadcrumbLink>
+                        ) : (
+                          <BreadcrumbPage>{selectedProject.name}</BreadcrumbPage>
+                        )}
+                      </BreadcrumbItem>
+                    </>
+                  ) : null}
+                  {selectedWorkspace && !isLoading ? (
+                    <>
+                      <BreadcrumbSeparator />
+                      <BreadcrumbItem>
+                        {selectedChat ? (
+                          <BreadcrumbLink
+                            href="#"
+                            onClick={(event) => {
+                              event.preventDefault()
+                              if (!selectedProject) {
+                                return
+                              }
+                              handleSelectWorkspace(
+                                selectedProject.id,
+                                selectedWorkspace.id
+                              )
+                            }}
+                          >
+                            {selectedWorkspace.name}
+                          </BreadcrumbLink>
+                        ) : (
+                          <BreadcrumbPage>{selectedWorkspace.name}</BreadcrumbPage>
+                        )}
+                      </BreadcrumbItem>
+                    </>
+                  ) : null}
+                  {selectedChat && !isLoading ? (
+                    <>
+                      <BreadcrumbSeparator />
+                      <BreadcrumbItem>
+                        <BreadcrumbPage>{selectedChat.name}</BreadcrumbPage>
+                      </BreadcrumbItem>
+                    </>
+                  ) : null}
                 </>
-              ) : null}
-              {selectedWorkspace && !isLoading ? (
-                <>
-                  <BreadcrumbSeparator />
-                  <BreadcrumbItem>
-                    {selectedChat ? (
-                      <BreadcrumbLink
-                        href="#"
-                        onClick={(event) => {
-                          event.preventDefault()
-                          if (!selectedProject) {
-                            return
-                          }
-                          handleSelectWorkspace(selectedProject.id, selectedWorkspace.id)
-                        }}
-                      >
-                        {selectedWorkspace.name}
-                      </BreadcrumbLink>
-                    ) : (
-                      <BreadcrumbPage>{selectedWorkspace.name}</BreadcrumbPage>
-                    )}
-                  </BreadcrumbItem>
-                </>
-              ) : null}
-              {selectedChat && !isLoading ? (
-                <>
-                  <BreadcrumbSeparator />
-                  <BreadcrumbItem>
-                    <BreadcrumbPage>{selectedChat.name}</BreadcrumbPage>
-                  </BreadcrumbItem>
-                </>
-              ) : null}
+              )}
             </BreadcrumbList>
           </Breadcrumb>
-          <div className="ml-auto flex items-center gap-2">
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              onClick={toggleTheme}
-              aria-label="Toggle dark mode"
-              title="Toggle dark mode"
-            >
-              {theme === "dark" ? <Sun /> : <Moon />}
-              <span className="sr-only">Toggle dark mode</span>
-            </Button>
-          </div>
         </header>
-        <div className="flex flex-1 flex-col gap-4 p-6">
+        {isSettingsView ? (
+          <div className="flex flex-1 flex-col gap-4 p-6">
+            <div className="rounded-xl border bg-card p-6 shadow-sm">
+              <div className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                Settings
+              </div>
+              <div className="mt-3 text-2xl font-semibold text-foreground">
+                Maestro preferences
+              </div>
+              <div className="mt-2 max-w-2xl text-sm text-muted-foreground">
+                Manage access tokens and appearance for this device.
+              </div>
+            </div>
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.9fr)]">
+              <Card>
+                <form onSubmit={handleSettingsSubmit}>
+                  <CardHeader>
+                    <CardTitle>Access tokens</CardTitle>
+                    <CardDescription>
+                      Keep your GitHub and Gotland integrations up to date.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="grid gap-4">
+                    <div className="grid gap-2">
+                      <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        GitHub token
+                      </label>
+                      <Input
+                        type="password"
+                        autoComplete="new-password"
+                        value={settingsForm.githubToken}
+                        onChange={handleSettingsChange("githubToken")}
+                        placeholder="ghp_..."
+                      />
+                      <div className="text-xs text-muted-foreground">
+                        Leave blank to clear. Environment variable GITHUB_TOKEN
+                        overrides this value.
+                      </div>
+                    </div>
+                    <div className="grid gap-2">
+                      <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        Gotland token
+                      </label>
+                      <Input
+                        type="password"
+                        autoComplete="new-password"
+                        value={settingsForm.gotlandToken}
+                        onChange={handleSettingsChange("gotlandToken")}
+                        placeholder="gotland_..."
+                      />
+                      <div className="text-xs text-muted-foreground">
+                        Stored locally in ~/.maestro/settings.json.
+                      </div>
+                    </div>
+                    {settingsError ? (
+                      <div className="rounded-md border border-destructive/50 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+                        {settingsError}
+                      </div>
+                    ) : null}
+                    {settingsSavedMessage ? (
+                      <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-700">
+                        {settingsSavedMessage}
+                      </div>
+                    ) : null}
+                  </CardContent>
+                  <CardFooter>
+                    <Button type="submit" disabled={isSavingSettings}>
+                      {isSavingSettings ? "Saving..." : "Save settings"}
+                    </Button>
+                  </CardFooter>
+                </form>
+              </Card>
+              <div className="grid gap-4">
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Appearance</CardTitle>
+                    <CardDescription>
+                      Choose the theme that feels best for long sessions.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="grid gap-3">
+                    <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border bg-muted/30 px-4 py-3">
+                      <div>
+                        <div className="text-sm font-semibold text-foreground">Theme</div>
+                        <div className="text-xs text-muted-foreground">
+                          Currently set to {theme === "dark" ? "dark" : "light"} mode.
+                        </div>
+                      </div>
+                      <Button type="button" variant="outline" onClick={toggleTheme}>
+                        Switch to {nextThemeLabel}
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Security</CardTitle>
+                    <CardDescription>
+                      Tokens stay on this machine unless you export them.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="text-sm text-muted-foreground">
+                    Maestro uses environment variables first, then falls back to your local
+                    settings file if needed.
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-1 flex-col gap-4 p-6">
           <div className="rounded-xl border bg-card p-6 shadow-sm">
             <div className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
               {viewLabel}
@@ -1948,7 +2165,8 @@ const App = () => {
               </div>
             </div>
           )}
-        </div>
+          </div>
+        )}
       </SidebarInset>
     </SidebarProvider>
   )

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { LifeBuoy, Send, Workflow } from "lucide-react"
+import { LifeBuoy, Send, Settings, Workflow } from "lucide-react"
 
 import { NavProjects } from "./nav-projects"
 import { NavSecondary } from "./nav-secondary"
@@ -9,6 +9,8 @@ import {
   SidebarContent,
   SidebarFooter,
   SidebarHeader,
+  SidebarGroup,
+  SidebarGroupContent,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
@@ -56,10 +58,12 @@ const data = {
 export function AppSidebar({
   projects,
   isProjectsView,
+  isSettingsView,
   selectedProjectId,
   selectedWorkspaceId,
   selectedChatId,
   onSelectProjects,
+  onSelectSettings,
   onSelectProject,
   onSelectWorkspace,
   onSelectChat,
@@ -67,10 +71,12 @@ export function AppSidebar({
 }: React.ComponentProps<typeof Sidebar> & {
   projects: Project[]
   isProjectsView: boolean
+  isSettingsView: boolean
   selectedProjectId: string | null
   selectedWorkspaceId: string | null
   selectedChatId: string | null
   onSelectProjects: () => void
+  onSelectSettings: () => void
   onSelectProject: (projectId: string) => void
   onSelectWorkspace: (projectId: string, workspaceId: string) => void
   onSelectChat: (projectId: string, workspaceId: string, chatId: string) => void
@@ -111,6 +117,24 @@ export function AppSidebar({
           onSelectWorkspace={onSelectWorkspace}
           onSelectChat={onSelectChat}
         />
+        <SidebarGroup>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  isActive={isSettingsView}
+                  onClick={(event) => {
+                    event.preventDefault()
+                    onSelectSettings()
+                  }}
+                >
+                  <Settings />
+                  <span>Settings</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
         <NavSecondary items={data.navSecondary} className="mt-auto" />
       </SidebarContent>
       <SidebarFooter>

--- a/packages/storage/src/index.d.ts
+++ b/packages/storage/src/index.d.ts
@@ -5,6 +5,11 @@ export interface MaestroPaths {
     conversationsDir: string;
     workspacesDir: string;
     currentFile: string;
+    settingsFile: string;
+}
+export interface MaestroSettings {
+    githubToken?: string;
+    gotlandToken?: string;
 }
 export declare const getMaestroPaths: (repoRoot: string) => MaestroPaths;
 export declare const ensureMaestroRoot: (repoRoot: string) => Promise<MaestroPaths>;
@@ -26,6 +31,8 @@ export declare const updateConversationTimestamp: (repoRoot: string, conversatio
 export declare const updateSessionTimestamp: (repoRoot: string, conversationId: string, session: Session) => Promise<void>;
 export declare const setCurrentContext: (repoRoot: string, context: CurrentContext) => Promise<void>;
 export declare const readCurrentContext: (repoRoot: string) => Promise<CurrentContext>;
+export declare const readSettings: (repoRoot: string) => Promise<MaestroSettings>;
+export declare const writeSettings: (repoRoot: string, settings: MaestroSettings) => Promise<void>;
 export declare const appendTranscriptEntry: (repoRoot: string, conversationId: string, sessionId: string, entry: unknown) => Promise<void>;
 export declare const appendEventEntry: (repoRoot: string, conversationId: string, sessionId: string, entry: unknown) => Promise<void>;
 export type TranscriptMessage = {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -15,6 +15,12 @@ export interface MaestroPaths {
   conversationsDir: string;
   workspacesDir: string;
   currentFile: string;
+  settingsFile: string;
+}
+
+export interface MaestroSettings {
+  githubToken?: string;
+  gotlandToken?: string;
 }
 
 export const getMaestroPaths = (_repoRoot: string): MaestroPaths => {
@@ -24,7 +30,8 @@ export const getMaestroPaths = (_repoRoot: string): MaestroPaths => {
     projectsDir: path.join(root, "projects"),
     conversationsDir: path.join(root, "conversations"),
     workspacesDir: path.join(root, "workspaces"),
-    currentFile: path.join(root, "current.json")
+    currentFile: path.join(root, "current.json"),
+    settingsFile: path.join(root, "settings.json")
   };
 };
 
@@ -250,6 +257,26 @@ export const readCurrentContext = async (repoRoot: string): Promise<CurrentConte
     }
     throw error;
   }
+};
+
+export const readSettings = async (repoRoot: string): Promise<MaestroSettings> => {
+  const { settingsFile } = getMaestroPaths(repoRoot);
+  try {
+    return await readJson<MaestroSettings>(settingsFile);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return {};
+    }
+    throw error;
+  }
+};
+
+export const writeSettings = async (
+  repoRoot: string,
+  settings: MaestroSettings
+): Promise<void> => {
+  const { settingsFile } = await ensureMaestroRoot(repoRoot);
+  await writeJson(settingsFile, settings);
 };
 
 export const appendTranscriptEntry = async (


### PR DESCRIPTION
## Summary
- add a Settings view with GitHub/Gotland token inputs and theme toggle
- persist settings via a new /api/settings endpoint backed by ~/.maestro/settings.json
- fall back to stored GitHub tokens when GITHUB_TOKEN is not set