### PR TITLE
ci: automate releases and add CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build_lint_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.1.30"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Test
+        run: bun run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,16 @@ jobs:
         with:
           bun-version: "1.1.30"
 
+      - name: Cache Bun and npm
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            ~/.npm
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,98 @@
+name: Publish NPM
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.1.30"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Determine next version
+        id: version
+        run: |
+          git fetch --tags --force
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$LAST_TAG" ]; then
+            BASE_VERSION="0.1.0"
+          else
+            BASE_VERSION="${LAST_TAG#v}"
+          fi
+          BUMP=$(npx -y conventional-recommended-bump -p angular || echo "patch")
+          if [ -z "$BUMP" ]; then
+            BUMP="patch"
+          fi
+          if [ -z "$LAST_TAG" ]; then
+            NEXT_VERSION="$BASE_VERSION"
+          else
+            NEXT_VERSION=$(npx -y semver "$BASE_VERSION" -i "$BUMP")
+          fi
+          echo "version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$NEXT_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        id: tag
+        env:
+          TAG_NAME: ${{ steps.version.outputs.tag }}
+        run: |
+          if git rev-parse -q --verify "refs/tags/$TAG_NAME" >/dev/null; then
+            echo "Tag $TAG_NAME already exists. Skipping publish."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git config user.name "github-actions"
+          git config user.email "github-actions@users.noreply.github.com"
+          git tag "$TAG_NAME"
+          git push origin "$TAG_NAME"
+          echo "should_publish=true" >> "$GITHUB_OUTPUT"
+
+      - name: Set versions from tag
+        if: steps.tag.outputs.should_publish == 'true'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          npm pkg set -w packages/core version="$VERSION"
+          npm pkg set -w packages/git version="$VERSION"
+          npm pkg set -w packages/opencode version="$VERSION"
+          npm pkg set -w packages/storage version="$VERSION"
+          npm pkg set -w apps/cli version="$VERSION"
+          npm pkg set -w apps/cli dependencies.@maestro/core="$VERSION"
+          npm pkg set -w apps/cli dependencies.@maestro/git="$VERSION"
+          npm pkg set -w apps/cli dependencies.@maestro/opencode="$VERSION"
+          npm pkg set -w apps/cli dependencies.@maestro/storage="$VERSION"
+          npm pkg set -w packages/storage dependencies.@maestro/core="$VERSION"
+
+      - name: Publish packages
+        if: steps.tag.outputs.should_publish == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm publish -w packages/core --access public
+          npm publish -w packages/git --access public
+          npm publish -w packages/opencode --access public
+          npm publish -w packages/storage --access public
+          npm publish -w apps/cli --access public

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -27,6 +27,16 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Cache Bun and npm
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            ~/.npm
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx --no-install commitlint --edit "$1"

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+};

--- a/package.json
+++ b/package.json
@@ -8,14 +8,26 @@
     "packages/*"
   ],
   "scripts": {
-    "dev": "turbo run dev --parallel",
+    "dev": "turbo run build && turbo run dev --parallel",
     "build": "turbo run build",
     "lint": "turbo run lint",
-    "test": "turbo run test"
+    "test": "turbo run test",
+    "prepare": "husky install",
+    "commit": "bunx cz"
   },
   "devDependencies": {
+    "@commitlint/cli": "^19.8.0",
+    "@commitlint/config-conventional": "^19.8.0",
     "@types/node": "^20.14.10",
+    "commitizen": "^4.3.0",
+    "cz-conventional-changelog": "^3.3.0",
+    "husky": "^9.0.11",
     "turbo": "^2.0.11",
     "typescript": "^5.6.3"
+  },
+  "config": {
+    "commitizen": {
+      "path": "cz-conventional-changelog"
+    }
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,7 @@
     }
   },
   "scripts": {
-    "build": "bun tsc -p tsconfig.json"
+    "build": "bun tsc -p tsconfig.json",
+    "dev": "bun tsc -p tsconfig.json --watch"
   }
 }

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "build": "bun tsc -p tsconfig.json",
+    "dev": "bun tsc -p tsconfig.json --watch",
     "test": "bun test"
   }
 }

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -11,7 +11,8 @@
     }
   },
   "scripts": {
-    "build": "bun tsc -p tsconfig.json"
+    "build": "bun tsc -p tsconfig.json",
+    "dev": "bun tsc -p tsconfig.json --watch"
   },
   "dependencies": {
     "@opencode-ai/sdk": "^1.0.0"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -11,7 +11,8 @@
     }
   },
   "scripts": {
-    "build": "bun tsc -p tsconfig.json"
+    "build": "bun tsc -p tsconfig.json",
+    "dev": "bun tsc -p tsconfig.json --watch"
   },
   "dependencies": {
     "@maestro/core": "0.0.0"

--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,7 @@
       "outputs": []
     },
     "dev": {
+      "dependsOn": ["^build", "^dev"],
       "cache": false,
       "persistent": true
     }


### PR DESCRIPTION
## Summary
- add CI workflow to run build, lint, and tests on PRs and main
- automate npm publishing with semver tagging from conventional commits
- enforce conventional commit messages with commitlint and husky