### PR TITLE
refactor(web): decompose workbench app with controllers and sections

### DIFF
--- a/MESSAGE_SCHEMA.md
+++ b/MESSAGE_SCHEMA.md
@@ -188,7 +188,7 @@ Used as a fast path for updating the text part and message content when streamin
 
 ## Client rendering and part mapping
 
-The web UI builds its rendering model from message parts in `apps/web/src/App.tsx`:
+The web UI builds its rendering model from message parts in `apps/web/src/features/workbench/message-entries.ts` and renders them in `apps/web/src/features/workbench/views/chat-view.tsx`:
 
 - Text is rendered from `getTextFromParts(parts)` (fallbacks to `content`).
 - `reasoning` parts are grouped and shown in the assistant reasoning panel.
@@ -209,8 +209,8 @@ When introducing a new structured part:
 
 1. Pick a unique `type` (prefer the `data-*` namespace for app-specific payloads).
 2. Ensure the server streams and stores the part with a stable `id` or `index` to support updates.
-3. Add a selector/mapping in `apps/web/src/App.tsx` to translate the new part into a render model.
-4. Render the new model in the chat view alongside other message sections.
+3. Add a selector/mapping in `apps/web/src/features/workbench/message-entries.ts` to translate the new part into a render model.
+4. Render the new model in `apps/web/src/features/workbench/views/chat-view.tsx` alongside other message sections.
 5. Update this document with the new part shape and any streaming notes.
 
 ## Legacy mapping rules

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,9 +7,9 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "node ./node_modules/vitest/vitest.mjs run",
-    "test:coverage": "node ./node_modules/vitest/vitest.mjs run --coverage",
-    "test:watch": "node ./node_modules/vitest/vitest.mjs"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@maestro/core": "0.0.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,160 +1,103 @@
 import * as React from "react"
 
-import { AppSidebar } from "./components/app-sidebar"
-import { ProjectWorkspacesTable } from "./components/project-workspaces-table"
-import type { PromptInputMessage } from "./components/ai-elements/prompt-input"
-import { SidebarInset, SidebarProvider, SidebarRail } from "./components/ui/sidebar"
 import { useTheme } from "./hooks/use-theme"
+import { ChatViewSection } from "./features/workbench/components/chat-view-section"
+import { WorkbenchContent } from "./features/workbench/components/workbench-content"
+import { WorkbenchHeaderSection } from "./features/workbench/components/workbench-header-section"
+import { WorkbenchLayout } from "./features/workbench/components/workbench-layout"
+import { WorkbenchMain } from "./features/workbench/components/workbench-main"
+import { ProjectWorkspacesSection } from "./features/workbench/components/project-workspaces-section"
+import { ProjectsViewSection } from "./features/workbench/components/projects-view-section"
+import { SettingsViewSection } from "./features/workbench/components/settings-view-section"
+import { WorkbenchSidebarSection } from "./features/workbench/components/workbench-sidebar-section"
+import { WorkspaceSessionsSection } from "./features/workbench/components/workspace-sessions-section"
+import { useChatController } from "./features/workbench/hooks/use-chat-controller"
+import { useChatModelOptions } from "./features/workbench/hooks/use-chat-model-options"
+import { useProjectsController } from "./features/workbench/hooks/use-projects-controller"
+import { usePullRequestsController } from "./features/workbench/hooks/use-pull-requests-controller"
+import { useSettingsController } from "./features/workbench/hooks/use-settings-controller"
+import { useWorkbenchViewModel } from "./features/workbench/hooks/use-workbench-view-model"
 import {
-  applyMessageDelta,
-  applyMessageEnd,
-  applyMessagePartUpdate,
-  createClientMessage,
-  getTextFromParts,
-  normalizeMessageParts,
-  type StructuredMessagePart,
-} from "./lib/messages"
-import { extractUsageFromMetadata } from "./features/workbench/message-entries"
-import {
-  buildModelOptions,
   collectAllWorkspaces,
   collectProjectRecentSessions,
   collectRecentSessions,
-  collectSettingsModels,
   filterProjectPullRequests,
-  getActiveProvider,
   hasProjectsWithRepos,
   sortOpenPullRequests,
 } from "./features/workbench/selectors"
 import { formatDate, formatDateTime } from "./features/workbench/date-format"
-import { ChatView } from "./features/workbench/views/chat-view"
-import { ProjectsView } from "./features/workbench/views/projects-view"
 import { SecondaryItemsView } from "./features/workbench/views/secondary-items-view"
-import { SettingsView } from "./features/workbench/views/settings-view"
-import { WorkbenchHeader } from "./features/workbench/views/workbench-header"
 import { WorkbenchOverview } from "./features/workbench/views/workbench-overview"
-import { WorkspaceSessionsView } from "./features/workbench/views/workspace-sessions-view"
-import type {
-  ApiConversation,
-  ApiModelsResponse,
-  ApiProject,
-  ApiPullRequest,
-  ApiSession,
-  ApiTranscriptEntry,
-  ChatSession,
-  ChatMessage,
-  CheckpointMarker,
-  SessionFormState,
-  CreateConversationResponse,
-  MergedPullRequestAction,
-  ModelProvider,
-  OpenPullRequest,
-  Project,
-  ProjectFormState,
-  SettingsFormState,
-  WorkspaceFormState,
-  Workspace,
-} from "./features/workbench/types"
+import { WorkbenchProvider, useWorkbench } from "./features/workbench/workbench-context"
 
-const App = () => {
+const WorkbenchShell = () => {
   const { theme, toggleTheme } = useTheme()
-  const [projects, setProjects] = React.useState<Project[]>([])
-  const [isLoading, setIsLoading] = React.useState(true)
-  const [error, setError] = React.useState<string | null>(null)
-  const [isProjectsView, setIsProjectsView] = React.useState(false)
-  const [isSettingsView, setIsSettingsView] = React.useState(false)
-  const [selectedProjectId, setSelectedProjectId] = React.useState<string | null>(
-    null
-  )
-  const [selectedWorkspaceId, setSelectedWorkspaceId] = React.useState<string | null>(
-    null
-  )
-  const [selectedChatId, setSelectedChatId] = React.useState<string | null>(null)
-  const [projectForm, setProjectForm] = React.useState<ProjectFormState>({
-    name: "",
-    repoPath: "",
-    defaultBranch: "main",
-    gitProvider: "",
-    repoUrl: "",
+  const { state, actions, meta } = useWorkbench()
+  const settings = useSettingsController()
+  const chat = useChatController()
+  const projectsController = useProjectsController({
+    settingsForm: settings.settingsForm,
+    addAvailableModel: settings.addAvailableModel,
   })
-  const [isCreatingProject, setIsCreatingProject] = React.useState(false)
-  const [isSelectingDirectory, setIsSelectingDirectory] = React.useState(false)
-  const [createProjectError, setCreateProjectError] = React.useState<string | null>(
-    null
-  )
-  const [workspaceForm, setWorkspaceForm] = React.useState<WorkspaceFormState>({
-    title: "",
-  })
-  const [isCreatingWorkspace, setIsCreatingWorkspace] = React.useState(false)
-  const [createWorkspaceError, setCreateWorkspaceError] = React.useState<string | null>(
-    null
-  )
-  const [sessionForm, setSessionForm] = React.useState<SessionFormState>({
-    providerId: "",
-    modelId: "",
-  })
-  const [isCreatingSession, setIsCreatingSession] = React.useState(false)
-  const [createSessionError, setCreateSessionError] = React.useState<string | null>(null)
-  const [deletingSessionId, setDeletingSessionId] = React.useState<string | null>(null)
-  const [deleteSessionError, setDeleteSessionError] = React.useState<string | null>(null)
-  const [deletingWorkspace, setDeletingWorkspace] = React.useState<
-    Record<string, boolean>
-  >({})
-  const [deleteWorkspaceErrors, setDeleteWorkspaceErrors] = React.useState<
-    Record<string, string>
-  >({})
-  const [messages, setMessages] = React.useState<ChatMessage[]>([])
-  const [copiedMessageId, setCopiedMessageId] = React.useState<string | null>(null)
-  const [chatStatus, setChatStatus] = React.useState<"idle" | "streaming" | "error">(
-    "idle"
-  )
-  const [chatError, setChatError] = React.useState<string | null>(null)
-  const [restoreCheckpointError, setRestoreCheckpointError] = React.useState<
-    string | null
-  >(null)
-  const [restoringCheckpoints, setRestoringCheckpoints] = React.useState<
-    Record<string, boolean>
-  >({})
-  const [promptValue, setPromptValue] = React.useState("")
-  const [isTranscriptLoading, setIsTranscriptLoading] = React.useState(false)
-  const [isAwaitingFirstToken, setIsAwaitingFirstToken] = React.useState(false)
-  const streamAbortRef = React.useRef<AbortController | null>(null)
-  const transcriptAbortRef = React.useRef<AbortController | null>(null)
-  const copyTimeoutRef = React.useRef<number | null>(null)
-  const [openPullRequests, setOpenPullRequests] = React.useState<OpenPullRequest[]>([])
-  const [isLoadingPullRequests, setIsLoadingPullRequests] = React.useState(false)
-  const [pullRequestsError, setPullRequestsError] = React.useState<string | null>(null)
-  const [settingsForm, setSettingsForm] = React.useState<SettingsFormState>({
-    githubToken: "",
-    gotlandToken: "",
-    modelProviders: [],
-    defaultProvider: "",
-    defaultModel: "",
-  })
-  const [settingsError, setSettingsError] = React.useState<string | null>(null)
-  const [settingsSavedMessage, setSettingsSavedMessage] = React.useState<string | null>(
-    null
-  )
-  const [isSavingSettings, setIsSavingSettings] = React.useState(false)
-  const [defaultModel, setDefaultModel] = React.useState<string | null>(null)
-  const [availableModels, setAvailableModels] = React.useState<string[]>([])
-  const [isUpdatingModel, setIsUpdatingModel] = React.useState(false)
-  const [updateModelError, setUpdateModelError] = React.useState<string | null>(null)
-  const [mergingPullRequests, setMergingPullRequests] = React.useState<
-    Record<string, boolean>
-  >({})
-  const [mergePullRequestErrors, setMergePullRequestErrors] = React.useState<
-    Record<string, string>
-  >({})
-  const [mergedPullRequests, setMergedPullRequests] = React.useState<
-    Record<string, MergedPullRequestAction>
-  >({})
-  const [deletingMergeWorkspace, setDeletingMergeWorkspace] = React.useState<
-    Record<string, boolean>
-  >({})
-  const [deleteMergeWorkspaceErrors, setDeleteMergeWorkspaceErrors] = React.useState<
-    Record<string, string>
-  >({})
+  const pullRequestsController = usePullRequestsController()
+
+  const { projects, isLoading, error, selectedProjectId, selectedWorkspaceId, selectedChatId } =
+    state
+  const {
+    selectedProject,
+    selectedWorkspace,
+    selectedChat,
+    isProjectsView,
+    isSettingsView,
+    isProjectView,
+    isWorkspaceView,
+    isChatView,
+  } = meta
+  const {
+    projectForm,
+    isCreatingProject,
+    isSelectingDirectory,
+    createProjectError,
+    workspaceForm,
+    isCreatingWorkspace,
+    createWorkspaceError,
+    isCreatingSession,
+    createSessionError,
+    deletingSessionId,
+    deleteSessionError,
+    deletingWorkspace,
+    deleteWorkspaceErrors,
+    isUpdatingModel,
+    updateModelError,
+  } = projectsController.state
+  const {
+    onProjectFormChange,
+    onWorkspaceFormChange,
+    onSelectDirectory,
+    onCreateProject,
+    onCreateWorkspace,
+    onDeleteWorkspace,
+    onConfirmDeleteWorkspace,
+    onCreateSession,
+    onDeleteSession,
+    onUpdateSessionModel,
+  } = projectsController.actions
+  const {
+    openPullRequests,
+    isLoadingPullRequests,
+    pullRequestsError,
+    mergingPullRequests,
+    mergePullRequestErrors,
+    mergedPullRequests,
+    deletingMergeWorkspace,
+    deleteMergeWorkspaceErrors,
+  } = pullRequestsController.state
+  const {
+    getPullRequestKey,
+    onMergePullRequest,
+    onDeleteMergedWorkspace,
+  } = pullRequestsController.actions
+
   const recentSessionsLimit = 6
   const emptyStateSuggestions = [
     "Summarize the repo focus",
@@ -163,298 +106,10 @@ const App = () => {
     "Explain the current workspace",
   ]
 
-  const loadProjects = React.useCallback(async () => {
-    setIsLoading(true)
-    setError(null)
-    try {
-      const [projectsRes, conversationsRes] = await Promise.all([
-        fetch("/api/projects?all=1"),
-        fetch("/api/conversations"),
-      ])
-      if (!projectsRes.ok) {
-        throw new Error("Failed to load projects.")
-      }
-      if (!conversationsRes.ok) {
-        throw new Error("Failed to load workspaces.")
-      }
-
-      const apiProjects = (await projectsRes.json()) as ApiProject[]
-      const conversations = (await conversationsRes.json()) as ApiConversation[]
-      const sessionsResults = await Promise.all(
-        conversations.map(async (conversation) => {
-          const response = await fetch(
-            `/api/conversations/${conversation.id}/sessions`
-          )
-          if (!response.ok) {
-            return { conversationId: conversation.id, sessions: [] as ApiSession[] }
-          }
-          const sessions = (await response.json()) as ApiSession[]
-          return { conversationId: conversation.id, sessions }
-        })
-      )
-
-      const sessionsByConversation = new Map(
-        sessionsResults.map((result) => [result.conversationId, result.sessions])
-      )
-
-      const nextProjects = apiProjects.map((project) => {
-        const projectConversations = conversations.filter(
-          (conversation) => conversation.projectId === project.id
-        )
-        const workspaces: Workspace[] = projectConversations.map((conversation) => {
-          const workspaceLabelFromPath = conversation.workspacePath
-            .split(/[\\/]/)
-            .filter(Boolean)
-            .pop()
-          const workspaceName =
-            conversation.title?.trim() ||
-            workspaceLabelFromPath ||
-            conversation.branch ||
-            conversation.id
-          const sessions = sessionsByConversation.get(conversation.id) ?? []
-          return {
-            id: conversation.id,
-            name: workspaceName,
-            branch: conversation.branch,
-            chats: sessions.map((session) => ({
-              id: session.id,
-              name: session.title?.trim() || session.model || session.id,
-              model: session.model,
-              createdAt: session.createdAt,
-              updatedAt: session.updatedAt,
-            })),
-            createdAt: conversation.createdAt,
-            updatedAt: conversation.updatedAt,
-          }
-        })
-
-        return {
-          id: project.id,
-          name: project.name,
-          icon: project.icon,
-          repoPath: project.repoPath,
-          defaultBranch: project.defaultBranch,
-          gitProvider: project.gitProvider,
-          repoUrl: project.repoUrl,
-          createdAt: project.createdAt,
-          updatedAt: project.updatedAt,
-          workspaces,
-        }
-      })
-
-      setProjects(nextProjects)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load projects.")
-      setProjects([])
-    } finally {
-      setIsLoading(false)
-    }
-  }, [])
-
-  const loadSettings = React.useCallback(async () => {
-    setSettingsError(null)
-    try {
-      const response = await fetch("/api/settings")
-      if (!response.ok) {
-        throw new Error("Failed to load settings.")
-      }
-      const payload = (await response.json()) as {
-        githubToken?: string
-        gotlandToken?: string
-        modelProviders?: ModelProvider[]
-        defaultProvider?: string
-        defaultModel?: string
-      }
-      setSettingsForm({
-        githubToken: payload.githubToken ?? "",
-        gotlandToken: payload.gotlandToken ?? "",
-        modelProviders: payload.modelProviders ?? [],
-        defaultProvider: payload.defaultProvider ?? "",
-        defaultModel: payload.defaultModel ?? "",
-      })
-    } catch (err) {
-      setSettingsError(
-        err instanceof Error ? err.message : "Failed to load settings."
-      )
-    }
-  }, [])
-
-  const loadModels = React.useCallback(async () => {
-    try {
-      const response = await fetch("/api/models")
-      if (!response.ok) {
-        return
-      }
-      const payload = (await response.json()) as ApiModelsResponse
-      const modelValues = Array.isArray(payload.models)
-        ? payload.models.map((model) => model.trim()).filter(Boolean)
-        : []
-      setDefaultModel(payload.defaultModel?.trim() || null)
-      setAvailableModels(Array.from(new Set(modelValues)))
-    } catch {
-      // Ignore model load errors and fall back to defaults
-    }
-  }, [])
-
-  React.useEffect(() => {
-    void loadProjects()
-  }, [loadProjects])
-
-  React.useEffect(() => {
-    void loadSettings()
-  }, [loadSettings])
-
-  React.useEffect(() => {
-    if (settingsForm.modelProviders.length === 0) {
-      return
-    }
-    setSessionForm((prev) => {
-      const providerIds = settingsForm.modelProviders.map((provider) => provider.id)
-      const resolvedProviderId = providerIds.includes(prev.providerId)
-        ? prev.providerId
-        : providerIds.includes(settingsForm.defaultProvider)
-          ? settingsForm.defaultProvider
-          : settingsForm.modelProviders[0]?.id || ""
-      const provider = settingsForm.modelProviders.find(
-        (item) => item.id === resolvedProviderId
-      )
-      const modelIds = provider?.models.map((model) => model.id) ?? []
-      const resolvedModelId = modelIds.includes(prev.modelId)
-        ? prev.modelId
-        : modelIds.includes(settingsForm.defaultModel)
-          ? settingsForm.defaultModel
-          : provider?.models[0]?.id || ""
-      if (
-        resolvedProviderId === prev.providerId &&
-        resolvedModelId === prev.modelId
-      ) {
-        return prev
-      }
-      return {
-        ...prev,
-        providerId: resolvedProviderId,
-        modelId: resolvedModelId,
-      }
-    })
-  }, [
-    settingsForm.modelProviders,
-    settingsForm.defaultProvider,
-    settingsForm.defaultModel,
-  ])
-
-  React.useEffect(() => {
-    if (settingsForm.modelProviders.length === 0) {
-      return
-    }
-    setSettingsForm((prev) => {
-      const providerIds = prev.modelProviders.map((provider) => provider.id)
-      const resolvedProviderId = providerIds.includes(prev.defaultProvider)
-        ? prev.defaultProvider
-        : prev.modelProviders[0]?.id || ""
-      const provider = prev.modelProviders.find(
-        (item) => item.id === resolvedProviderId
-      )
-      const modelIds = provider?.models.map((model) => model.id) ?? []
-      const resolvedModelId = modelIds.includes(prev.defaultModel)
-        ? prev.defaultModel
-        : provider?.models[0]?.id || ""
-      if (
-        resolvedProviderId === prev.defaultProvider &&
-        resolvedModelId === prev.defaultModel
-      ) {
-        return prev
-      }
-      return {
-        ...prev,
-        defaultProvider: resolvedProviderId,
-        defaultModel: resolvedModelId,
-      }
-    })
-  }, [settingsForm.modelProviders])
-
-  React.useEffect(() => {
-    void loadModels()
-  }, [loadModels])
-
-  React.useEffect(() => {
-    if (!projects.length) {
-      setSelectedProjectId(null)
-      setSelectedWorkspaceId(null)
-      setSelectedChatId(null)
-      return
-    }
-    if (isProjectsView) {
-      setSelectedProjectId(null)
-      setSelectedWorkspaceId(null)
-      setSelectedChatId(null)
-      return
-    }
-    const project =
-      projects.find((item) => item.id === selectedProjectId) ?? projects[0]
-    const shouldSelectWorkspace =
-      selectedWorkspaceId !== null ||
-      selectedChatId !== null ||
-      selectedProjectId === null
-    const workspace = shouldSelectWorkspace
-      ? project.workspaces.find((item) => item.id === selectedWorkspaceId) ??
-        project.workspaces[0] ??
-        null
-      : null
-    const chat = shouldSelectWorkspace
-      ? workspace?.chats.find((item) => item.id === selectedChatId) ??
-        workspace?.chats[0] ??
-        null
-      : null
-    setSelectedProjectId(project.id)
-    setSelectedWorkspaceId(workspace?.id ?? null)
-    setSelectedChatId(chat?.id ?? null)
-  }, [projects, isProjectsView])
-
-  const selectedProject = React.useMemo(
-    () => projects.find((project) => project.id === selectedProjectId) ?? null,
-    [projects, selectedProjectId]
-  )
-  const selectedWorkspace = React.useMemo(
-    () =>
-      selectedProject?.workspaces.find(
-        (workspace) => workspace.id === selectedWorkspaceId
-      ) ?? null,
-    [selectedProject, selectedWorkspaceId]
-  )
-  const selectedChat = React.useMemo(
-    () =>
-      selectedWorkspace?.chats.find((chat) => chat.id === selectedChatId) ?? null,
-    [selectedWorkspace, selectedChatId]
-  )
-
-  const fallbackModel = defaultModel?.trim() || "openai/gpt-5.3-codex"
-  const selectedModel = selectedChat?.model ?? fallbackModel
-  const activeProvider = React.useMemo(() => getActiveProvider(selectedModel), [selectedModel])
-  const settingsModels = React.useMemo(
-    () => collectSettingsModels(settingsForm.modelProviders),
-    [settingsForm.modelProviders]
-  )
-  const modelOptions = React.useMemo(
-    () =>
-      buildModelOptions({
-        fallbackModel,
-        availableModels,
-        settingsModels,
-        selectedChatModel: selectedChat?.model,
-        activeProvider,
-      }),
-    [activeProvider, availableModels, fallbackModel, selectedChat?.model, settingsModels]
-  )
-  const usageFromMessages = React.useMemo(() => {
-    for (let index = messages.length - 1; index >= 0; index -= 1) {
-      const usage = extractUsageFromMetadata(messages[index]?.metadata)
-      if (usage) {
-        return usage
-      }
-    }
-    return null
-  }, [messages])
-  const contextUsage = usageFromMessages ?? undefined
+  const { selectedModel, modelOptions } = useChatModelOptions({
+    settings,
+    selectedChat,
+  })
 
   const recentSessions = React.useMemo(
     () => collectRecentSessions(projects, recentSessionsLimit),
@@ -479,1493 +134,208 @@ const App = () => {
   )
 
   const hasRepoProjects = React.useMemo(() => hasProjectsWithRepos(projects), [projects])
-  const getPullRequestKey = React.useCallback((item: OpenPullRequest) => {
-    return `${item.projectId}:${item.number}`
-  }, [])
-  const findWorkspaceForPullRequest = React.useCallback(
-    (item: OpenPullRequest) => {
-      const sourceBranch = item.sourceBranch?.trim().toLowerCase()
-      if (!sourceBranch) {
-        return undefined
-      }
-      const project = projects.find((entry) => entry.id === item.projectId)
-      if (!project) {
-        return undefined
-      }
-      return project.workspaces.find((workspace) => {
-        const branch = workspace.branch?.trim().toLowerCase()
-        return branch && branch === sourceBranch
-      })
-    },
-    [projects]
-  )
-  const createLocalMessageId = React.useCallback(() => {
-    return `m_${Math.random().toString(36).slice(2, 10)}`
-  }, [])
-  const createLocalFileId = React.useCallback(() => {
-    return `f_${Math.random().toString(36).slice(2, 10)}`
-  }, [])
-
-  React.useEffect(() => {
-    return () => {
-      if (copyTimeoutRef.current !== null) {
-        window.clearTimeout(copyTimeoutRef.current)
-      }
-    }
-  }, [])
-
-  const fetchTranscript = React.useCallback(
-    async (conversationId: string, sessionId: string, signal: AbortSignal) => {
-      const response = await fetch(
-        `/api/conversations/${conversationId}/sessions/${sessionId}/transcript`,
-        { signal }
-      )
-      if (!response.ok) {
-        throw new Error("Failed to load transcript.")
-      }
-      const transcript = (await response.json()) as ApiTranscriptEntry[]
-      setMessages(
-        transcript.map((entry) =>
-          createClientMessage({
-            id: createLocalMessageId(),
-            role: entry.role,
-            content: entry.content,
-            parts: entry.parts,
-            metadata: entry.metadata,
-          })
-        )
-      )
-    },
-    [createLocalMessageId]
-  )
-
-  const loadTranscript = React.useCallback(
-    async (resetPrompt: boolean) => {
-      streamAbortRef.current?.abort()
-      transcriptAbortRef.current?.abort()
-      if (resetPrompt) {
-        setMessages([])
-        setPromptValue("")
-        setChatStatus("idle")
-        setChatError(null)
-        setRestoreCheckpointError(null)
-        setIsAwaitingFirstToken(false)
-      }
-      const conversationId = selectedWorkspace?.id
-      const sessionId = selectedChat?.id
-      if (!conversationId || !sessionId) {
-        setIsTranscriptLoading(false)
-        return
-      }
-      const controller = new AbortController()
-      transcriptAbortRef.current = controller
-      setIsTranscriptLoading(true)
-      try {
-        await fetchTranscript(conversationId, sessionId, controller.signal)
-      } catch (err) {
-        if (controller.signal.aborted) {
-          return
-        }
-        setChatError(err instanceof Error ? err.message : "Failed to load transcript.")
-        setMessages([])
-      } finally {
-        if (!controller.signal.aborted) {
-          setIsTranscriptLoading(false)
-        }
-      }
-    },
-    [selectedWorkspace?.id, selectedChat?.id, fetchTranscript]
-  )
-
-  React.useEffect(() => {
-    void loadTranscript(true)
-  }, [selectedWorkspace?.id, selectedChat?.id, loadTranscript])
-
-  React.useEffect(() => {
-    if (!selectedWorkspaceId) {
-      return
-    }
-    setDeleteWorkspaceErrors((prev) => {
-      const next = { ...prev }
-      delete next[selectedWorkspaceId]
-      return next
-    })
-  }, [selectedWorkspaceId])
-
-  React.useEffect(() => {
-    setDeleteSessionError(null)
-  }, [selectedWorkspaceId])
-
-  React.useEffect(() => {
-    setUpdateModelError(null)
-  }, [selectedChatId])
-
-  React.useEffect(() => {
-    if (!projects.length) {
-      setOpenPullRequests([])
-      setPullRequestsError(null)
-      return
-    }
-    let isActive = true
-    const loadPullRequests = async () => {
-      const targets = projects.filter((project) => project.repoUrl?.trim())
-      if (!targets.length) {
-        if (isActive) {
-          setOpenPullRequests([])
-          setPullRequestsError(null)
-          setIsLoadingPullRequests(false)
-        }
-        return
-      }
-      setIsLoadingPullRequests(true)
-      setPullRequestsError(null)
-      const errors: string[] = []
-      const results = await Promise.all(
-        targets.map(async (project) => {
-          try {
-            const response = await fetch(
-              `/api/projects/${project.id}/pull-requests?limit=10`
-            )
-            if (!response.ok) {
-              let message = `Failed to load pull requests for ${project.name}.`
-              try {
-                const payload = (await response.json()) as { error?: string }
-                if (payload.error) {
-                  message = payload.error
-                }
-              } catch {
-                // Ignore parsing errors
-              }
-              errors.push(message)
-              return [] as OpenPullRequest[]
-            }
-            const payload = (await response.json()) as ApiPullRequest[]
-            return payload.map((item) => ({
-              ...item,
-              projectId: project.id,
-              projectName: project.name,
-            }))
-          } catch (err) {
-            errors.push(
-              err instanceof Error
-                ? err.message
-                : `Failed to load pull requests for ${project.name}.`
-            )
-            return [] as OpenPullRequest[]
-          }
-        })
-      )
-      if (!isActive) {
-        return
-      }
-      const flattened = results.flat()
-      setOpenPullRequests(flattened)
-      setPullRequestsError(flattened.length ? null : errors[0] ?? null)
-      setIsLoadingPullRequests(false)
-    }
-    void loadPullRequests()
-    return () => {
-      isActive = false
-    }
-  }, [projects])
-
-  const handleSelectProjectsView = () => {
-    setIsProjectsView(true)
-    setIsSettingsView(false)
-    setSelectedProjectId(null)
-    setSelectedWorkspaceId(null)
-    setSelectedChatId(null)
-  }
-
-  const handleSelectSettingsView = () => {
-    setIsSettingsView(true)
-    setIsProjectsView(false)
-  }
-
-  const handleSelectProject = (projectId: string) => {
-    setIsProjectsView(false)
-    setIsSettingsView(false)
-    setSelectedProjectId(projectId)
-    setSelectedWorkspaceId(null)
-    setSelectedChatId(null)
-  }
-
-  const handleSelectWorkspace = (projectId: string, workspaceId: string) => {
-    setIsProjectsView(false)
-    setIsSettingsView(false)
-    setSelectedProjectId(projectId)
-    setSelectedWorkspaceId(workspaceId)
-    setSelectedChatId(null)
-  }
-
-  const handleMergePullRequest = async (item: OpenPullRequest) => {
-    const key = getPullRequestKey(item)
-    if (mergingPullRequests[key]) {
-      return
-    }
-    const workspace = findWorkspaceForPullRequest(item)
-    setMergingPullRequests((prev) => ({ ...prev, [key]: true }))
-    setMergePullRequestErrors((prev) => {
-      const next = { ...prev }
-      delete next[key]
-      return next
-    })
-    try {
-      if (workspace) {
-        const statusResponse = await fetch(
-          `/api/conversations/${workspace.id}/status`
-        )
-        if (!statusResponse.ok) {
-          if (statusResponse.status !== 404) {
-            let message = "Failed to check workspace status."
-            try {
-              const payload = (await statusResponse.json()) as { error?: string }
-              if (payload.error) {
-                message = payload.error
-              }
-            } catch {
-              // Ignore parsing errors
-            }
-            throw new Error(message)
-          }
-        } else {
-          const payload = (await statusResponse.json()) as { dirty?: boolean }
-          if (payload.dirty) {
-            const confirmed = window.confirm(
-              `Workspace "${workspace.name}" has uncommitted changes. Merge anyway?`
-            )
-            if (!confirmed) {
-              return
-            }
-          }
-        }
-      }
-      const response = await fetch(
-        `/api/projects/${item.projectId}/pull-requests/${item.number}/merge`,
-        { method: "POST" }
-      )
-      if (!response.ok) {
-        let message = "Failed to merge pull request."
-        try {
-          const payload = (await response.json()) as { error?: string }
-          if (payload.error) {
-            message = payload.error
-          }
-        } catch {
-          // Ignore parsing errors
-        }
-        if (response.status === 404 && message === "Not Found") {
-          message =
-            "Merge endpoint not found. Restart the CLI server to pick up the merge API."
-        }
-        throw new Error(message)
-      }
-      setMergedPullRequests((prev) => ({
-        ...prev,
-        [key]: {
-          workspaceId: workspace?.id,
-          workspaceName: workspace?.name,
-        },
-      }))
-    } catch (err) {
-      setMergePullRequestErrors((prev) => ({
-        ...prev,
-        [key]: err instanceof Error ? err.message : "Failed to merge pull request.",
-      }))
-    } finally {
-      setMergingPullRequests((prev) => ({ ...prev, [key]: false }))
-    }
-  }
-
-  const handleDeleteMergedWorkspace = async (
-    pullRequestKey: string,
-    workspaceId: string,
-    workspaceName?: string
-  ) => {
-    const label = workspaceName || workspaceId
-    const confirmed = window.confirm(
-      `Delete workspace "${label}"? This removes the worktree and all sessions.`
-    )
-    if (!confirmed) {
-      return
-    }
-    setDeletingMergeWorkspace((prev) => ({ ...prev, [workspaceId]: true }))
-    setDeleteMergeWorkspaceErrors((prev) => {
-      const next = { ...prev }
-      delete next[workspaceId]
-      return next
-    })
-    try {
-      const response = await fetch(`/api/conversations/${workspaceId}?confirm=true`, {
-        method: "DELETE",
-      })
-      if (!response.ok) {
-        let message = "Failed to delete workspace."
-        try {
-          const payload = (await response.json()) as { error?: string }
-          if (payload.error) {
-            message = payload.error
-          }
-        } catch {
-          // Ignore parsing errors
-        }
-        throw new Error(message)
-      }
-      await loadProjects()
-      setMergedPullRequests((prev) => ({
-        ...prev,
-        [pullRequestKey]: {
-          ...prev[pullRequestKey],
-          workspaceDeleted: true,
-        },
-      }))
-    } catch (err) {
-      setDeleteMergeWorkspaceErrors((prev) => ({
-        ...prev,
-        [workspaceId]:
-          err instanceof Error ? err.message : "Failed to delete workspace.",
-      }))
-    } finally {
-      setDeletingMergeWorkspace((prev) => ({ ...prev, [workspaceId]: false }))
-    }
-  }
-
-  const handleSelectChat = (
-    projectId: string,
-    workspaceId: string,
-    chatId: string
-  ) => {
-    setIsProjectsView(false)
-    setIsSettingsView(false)
-    setSelectedProjectId(projectId)
-    setSelectedWorkspaceId(workspaceId)
-    setSelectedChatId(chatId)
-  }
-
-  const handleProjectFormChange = (field: keyof typeof projectForm) => {
-    return (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
-      const value = event.target.value
-      setProjectForm((prev) => ({ ...prev, [field]: value }))
-    }
-  }
-
-  const handleSettingsChange = (field: "githubToken" | "gotlandToken") => {
-    return (event: React.ChangeEvent<HTMLInputElement>) => {
-      const value = event.target.value
-      setSettingsForm((prev) => ({ ...prev, [field]: value }))
-      setSettingsSavedMessage(null)
-    }
-  }
-
-  const handleWorkspaceFormChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value
-    setWorkspaceForm({ title: value })
-  }
-
-  const updateModelProvider = (
-    index: number,
-    updater: (provider: ModelProvider) => ModelProvider
-  ) => {
-    setSettingsForm((prev) => {
-      const nextProviders = prev.modelProviders.map((provider, providerIndex) =>
-        providerIndex === index ? updater(provider) : provider
-      )
-      return { ...prev, modelProviders: nextProviders }
-    })
-    setSettingsSavedMessage(null)
-  }
-
-  const handleAddProvider = () => {
-    setSettingsForm((prev) => ({
-      ...prev,
-      modelProviders: [
-        ...prev.modelProviders,
-        { id: "", name: "", models: [] },
-      ],
-    }))
-    setSettingsSavedMessage(null)
-  }
-
-  const handleRemoveProvider = (index: number) => {
-    setSettingsForm((prev) => ({
-      ...prev,
-      modelProviders: prev.modelProviders.filter((_, providerIndex) => providerIndex !== index),
-    }))
-    setSettingsSavedMessage(null)
-  }
-
-  const handleAddModel = (providerIndex: number) => {
-    updateModelProvider(providerIndex, (provider) => ({
-      ...provider,
-      models: [...provider.models, { id: "", name: "" }],
-    }))
-  }
-
-  const handleRemoveModel = (providerIndex: number, modelIndex: number) => {
-    updateModelProvider(providerIndex, (provider) => ({
-      ...provider,
-      models: provider.models.filter((_, index) => index !== modelIndex),
-    }))
-  }
-
-  const handleDefaultProviderChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const value = event.target.value
-    setSettingsForm((prev) => {
-      const provider = prev.modelProviders.find((item) => item.id === value)
-      const modelId =
-        provider?.models.find((model) => model.id === prev.defaultModel)?.id ??
-        provider?.models[0]?.id ??
-        ""
-      return { ...prev, defaultProvider: value, defaultModel: modelId }
-    })
-    setSettingsSavedMessage(null)
-  }
-
-  const handleDefaultModelChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const value = event.target.value
-    setSettingsForm((prev) => ({ ...prev, defaultModel: value }))
-    setSettingsSavedMessage(null)
-  }
-  const handleSettingsSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    setIsSavingSettings(true)
-    setSettingsError(null)
-    setSettingsSavedMessage(null)
-    try {
-      const response = await fetch("/api/settings", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          githubToken: settingsForm.githubToken.trim() || null,
-          gotlandToken: settingsForm.gotlandToken.trim() || null,
-          modelProviders: settingsForm.modelProviders,
-          defaultProvider: settingsForm.defaultProvider.trim() || null,
-          defaultModel: settingsForm.defaultModel.trim() || null,
-        }),
-      })
-      if (!response.ok) {
-        let message = "Failed to save settings."
-        try {
-          const payload = (await response.json()) as { error?: string }
-          if (payload.error) {
-            message = payload.error
-          }
-        } catch {
-          // Ignore parsing errors
-        }
-        throw new Error(message)
-      }
-      const payload = (await response.json()) as {
-        githubToken?: string
-        gotlandToken?: string
-        modelProviders?: ModelProvider[]
-        defaultProvider?: string
-        defaultModel?: string
-      }
-      setSettingsForm({
-        githubToken: payload.githubToken ?? "",
-        gotlandToken: payload.gotlandToken ?? "",
-        modelProviders: payload.modelProviders ?? [],
-        defaultProvider: payload.defaultProvider ?? "",
-        defaultModel: payload.defaultModel ?? "",
-      })
-      setSettingsSavedMessage("Settings saved.")
-    } catch (err) {
-      setSettingsError(
-        err instanceof Error ? err.message : "Failed to save settings."
-      )
-    } finally {
-      setIsSavingSettings(false)
-    }
-  }
-
-  const handleSelectDirectory = async () => {
-    setIsSelectingDirectory(true)
-    setCreateProjectError(null)
-    try {
-      const response = await fetch("/api/fs/select-directory", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ startPath: projectForm.repoPath || undefined }),
-      })
-      if (!response.ok) {
-        let message = "Failed to select folder."
-        try {
-          const payload = (await response.json()) as { error?: string }
-          if (payload.error) {
-            message = payload.error
-          }
-        } catch {
-          // Ignore parsing errors
-        }
-        throw new Error(message)
-      }
-      const payload = (await response.json()) as { path?: string }
-      if (payload.path) {
-        setProjectForm((prev) => ({ ...prev, repoPath: payload.path ?? "" }))
-      }
-    } catch (err) {
-      setCreateProjectError(
-        err instanceof Error ? err.message : "Failed to select folder."
-      )
-    } finally {
-      setIsSelectingDirectory(false)
-    }
-  }
-
-  const handleCreateProject = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const name = projectForm.name.trim()
-    if (!name) {
-      setCreateProjectError("Project name is required.")
-      return
-    }
-    const defaultBranch = projectForm.defaultBranch.trim() || "main"
-    const repoPath = projectForm.repoPath.trim()
-
-    setIsCreatingProject(true)
-    setCreateProjectError(null)
-    try {
-      const response = await fetch("/api/projects", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name,
-          defaultBranch,
-          repoPath: repoPath || undefined,
-          gitProvider: projectForm.gitProvider || undefined,
-          repoUrl: projectForm.repoUrl.trim() || undefined,
-        }),
-      })
-      if (!response.ok) {
-        let message = "Failed to create project."
-        try {
-          const payload = (await response.json()) as { error?: string }
-          if (payload.error) {
-            message = payload.error
-          }
-        } catch {
-          // Ignore parsing errors
-        }
-        throw new Error(message)
-      }
-      const createdProject = (await response.json()) as ApiProject
-      setProjectForm({
-        name: "",
-        repoPath: "",
-        defaultBranch: defaultBranch,
-        gitProvider: "",
-        repoUrl: "",
-      })
-      setIsProjectsView(false)
-      setSelectedProjectId(createdProject.id)
-      setSelectedWorkspaceId(null)
-      setSelectedChatId(null)
-      await loadProjects()
-    } catch (err) {
-      setCreateProjectError(
-        err instanceof Error ? err.message : "Failed to create project."
-      )
-    } finally {
-      setIsCreatingProject(false)
-    }
-  }
-
-  const handleCreateWorkspace = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!selectedProject) {
-      return
-    }
-    const title = workspaceForm.title.trim()
-    setIsCreatingWorkspace(true)
-    setCreateWorkspaceError(null)
-    try {
-      const response = await fetch("/api/conversations", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          projectId: selectedProject.id,
-          title: title || undefined,
-        }),
-      })
-      if (!response.ok) {
-        let message = "Failed to create workspace."
-        try {
-          const payload = (await response.json()) as { error?: string }
-          if (payload.error) {
-            message = payload.error
-          }
-        } catch {
-          // Ignore parsing errors
-        }
-        throw new Error(message)
-      }
-      const payload = (await response.json()) as CreateConversationResponse
-      setWorkspaceForm({ title: "" })
-      setIsProjectsView(false)
-      setSelectedProjectId(payload.project.id)
-      setSelectedWorkspaceId(payload.conversation.id)
-      setSelectedChatId(payload.session.id)
-      await loadProjects()
-    } catch (err) {
-      setCreateWorkspaceError(
-        err instanceof Error ? err.message : "Failed to create workspace."
-      )
-    } finally {
-      setIsCreatingWorkspace(false)
-    }
-  }
-
-  const handleDeleteWorkspace = async (workspaceId: string, workspaceName?: string) => {
-    setDeletingWorkspace((prev) => ({ ...prev, [workspaceId]: true }))
-    setDeleteWorkspaceErrors((prev) => {
-      const next = { ...prev }
-      delete next[workspaceId]
-      return next
-    })
-    try {
-      const response = await fetch(`/api/conversations/${workspaceId}?confirm=true`, {
-        method: "DELETE",
-      })
-      if (!response.ok) {
-        let message = "Failed to delete workspace."
-        try {
-          const payload = (await response.json()) as { error?: string }
-          if (payload.error) {
-            message = payload.error
-          }
-        } catch {
-          // Ignore parsing errors
-        }
-        throw new Error(message)
-      }
-      if (selectedWorkspace?.id === workspaceId) {
-        setSelectedWorkspaceId(null)
-        setSelectedChatId(null)
-      }
-      await loadProjects()
-      return true
-    } catch (err) {
-      setDeleteWorkspaceErrors((prev) => ({
-        ...prev,
-        [workspaceId]:
-          err instanceof Error ? err.message : "Failed to delete workspace.",
-      }))
-      return false
-    } finally {
-      setDeletingWorkspace((prev) => ({ ...prev, [workspaceId]: false }))
-    }
-  }
-
-  const handleConfirmDeleteWorkspace = async (
-    workspaceId: string,
-    workspaceName?: string
-  ) => {
-    const workspaceLabel = workspaceName || workspaceId
-    const confirmed = window.confirm(
-      `Delete workspace "${workspaceLabel}"? This removes the worktree and all sessions.`
-    )
-    if (!confirmed) {
-      return false
-    }
-    return handleDeleteWorkspace(workspaceId, workspaceName)
-  }
-
-  const handleCreateSession = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!selectedProject || !selectedWorkspace) {
-      return
-    }
-    const title = ""
-    const providerId = sessionForm.providerId.trim()
-    const modelId = sessionForm.modelId.trim()
-    const model = providerId && modelId ? `${providerId}/${modelId}` : undefined
-    setIsCreatingSession(true)
-    setCreateSessionError(null)
-    try {
-      const response = await fetch(
-        `/api/conversations/${selectedWorkspace.id}/sessions`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ title: title || undefined, model }),
-        }
-      )
-      if (!response.ok) {
-        let message = "Failed to create session."
-        try {
-          const payload = (await response.json()) as { error?: string }
-          if (payload.error) {
-            message = payload.error
-          }
-        } catch {
-          // Ignore parsing errors
-        }
-        throw new Error(message)
-      }
-      const session = (await response.json()) as ApiSession
-      const nextChat: ChatSession = {
-        id: session.id,
-        name: session.title?.trim() || session.model || session.id,
-        model: session.model,
-        createdAt: session.createdAt,
-        updatedAt: session.updatedAt,
-      }
-      setIsProjectsView(false)
-      setSelectedProjectId(selectedProject.id)
-      setSelectedWorkspaceId(selectedWorkspace.id)
-      setSelectedChatId(session.id)
-      setProjects((current) =>
-        current.map((project) => {
-          if (project.id !== selectedProject.id) {
-            return project
-          }
-          return {
-            ...project,
-            workspaces: project.workspaces.map((workspace) => {
-              if (workspace.id !== selectedWorkspace.id) {
-                return workspace
-              }
-              const existing = workspace.chats.some((chat) => chat.id === session.id)
-              if (existing) {
-                return workspace
-              }
-              return {
-                ...workspace,
-                chats: [nextChat, ...workspace.chats],
-              }
-            }),
-          }
-        })
-      )
-      await loadProjects()
-    } catch (err) {
-      setCreateSessionError(
-        err instanceof Error ? err.message : "Failed to create session."
-      )
-    } finally {
-      setIsCreatingSession(false)
-    }
-  }
-
-  const handleDeleteSession = async (sessionId: string) => {
-    if (!selectedProject || !selectedWorkspace) {
-      return
-    }
-    const sessionLabel =
-      selectedWorkspace.chats.find((chat) => chat.id === sessionId)?.name || sessionId
-    const confirmed = window.confirm(`Delete session "${sessionLabel}"?`)
-    if (!confirmed) {
-      return
-    }
-    setDeletingSessionId(sessionId)
-    setDeleteSessionError(null)
-    try {
-      const response = await fetch(
-        `/api/conversations/${selectedWorkspace.id}/sessions/${sessionId}?confirm=true`,
-        {
-          method: "DELETE",
-        }
-      )
-      if (!response.ok) {
-        let message = "Failed to delete session."
-        try {
-          const payload = (await response.json()) as { error?: string }
-          if (payload.error) {
-            message = payload.error
-          }
-        } catch {
-          // Ignore parsing errors
-        }
-        throw new Error(message)
-      }
-      if (selectedChatId === sessionId) {
-        setSelectedChatId(null)
-      }
-      await loadProjects()
-    } catch (err) {
-      setDeleteSessionError(
-        err instanceof Error ? err.message : "Failed to delete session."
-      )
-    } finally {
-      setDeletingSessionId((current) => (current === sessionId ? null : current))
-    }
-  }
-
-  const handleUpdateSessionModel = async (modelId: string) => {
-    if (!selectedWorkspace || !selectedChat) {
-      return
-    }
-    if (selectedChat.model === modelId) {
-      return
-    }
-    setIsUpdatingModel(true)
-    setUpdateModelError(null)
-    try {
-      const response = await fetch(
-        `/api/conversations/${selectedWorkspace.id}/sessions/${selectedChat.id}`,
-        {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ model: modelId }),
-        }
-      )
-      if (!response.ok) {
-        let message = "Failed to update session model."
-        try {
-          const payload = (await response.json()) as { error?: string }
-          if (payload.error) {
-            message = payload.error
-          }
-        } catch {
-          // Ignore parsing errors
-        }
-        throw new Error(message)
-      }
-      const updatedSession = (await response.json()) as ApiSession
-      setProjects((prev) =>
-        prev.map((project) => ({
-          ...project,
-          workspaces: project.workspaces.map((workspace) => {
-            if (workspace.id !== updatedSession.conversationId) {
-              return workspace
-            }
-            return {
-              ...workspace,
-              chats: workspace.chats.map((chat) =>
-                chat.id === updatedSession.id
-                  ? {
-                      ...chat,
-                      name:
-                        updatedSession.title?.trim() ||
-                        updatedSession.model ||
-                        updatedSession.id,
-                      model: updatedSession.model,
-                      updatedAt: updatedSession.updatedAt,
-                    }
-                  : chat
-              ),
-            }
-          }),
-        }))
-      )
-      const updatedModel = updatedSession.model?.trim()
-      if (updatedModel) {
-        setAvailableModels((prev) =>
-          prev.includes(updatedModel) ? prev : [...prev, updatedModel]
-        )
-      }
-    } catch (err) {
-      setUpdateModelError(
-        err instanceof Error ? err.message : "Failed to update session model."
-      )
-    } finally {
-      setIsUpdatingModel(false)
-    }
-  }
-
-  const handlePromptChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setPromptValue(event.target.value)
-  }
-
-  const handleSuggestionClick = React.useCallback((suggestion: string) => {
-    setPromptValue(suggestion)
-    if (typeof document === "undefined") {
-      return
-    }
-    window.requestAnimationFrame(() => {
-      const textarea = document.querySelector(
-        'textarea[name="message"]'
-      ) as HTMLTextAreaElement | null
-      if (!textarea) {
-        return
-      }
-      textarea.focus()
-      textarea.setSelectionRange(suggestion.length, suggestion.length)
-    })
-  }, [])
-
-  const handlePromptSubmit = async (message: PromptInputMessage) => {
-    if (!selectedWorkspace || !selectedChat) {
-      return
-    }
-    if (chatStatus === "streaming") {
-      return
-    }
-    const content = message.text.trim()
-    if (!content) {
-      return
-    }
-
-    const conversationId = selectedWorkspace.id
-    const sessionId = selectedChat.id
-    const userMessageId = createLocalMessageId()
-    const assistantMessageId = createLocalMessageId()
-    const attachmentParts: StructuredMessagePart[] = message.files.map((file) => {
-      const attachmentId = createLocalFileId()
-      return {
-        type: "file",
-        id: attachmentId,
-        file: {
-          id: attachmentId,
-          name: file.filename,
-          path: file.url,
-          mimeType: file.mediaType,
-          size: file.size,
-          source: "upload",
-        },
-      }
-    })
-    const userParts = normalizeMessageParts(content, [
-      { type: "text", text: content },
-      ...attachmentParts,
-    ])
-
-    setPromptValue("")
-    setChatError(null)
-    setIsAwaitingFirstToken(true)
-    setChatStatus("streaming")
-    setMessages((prev) => [
-      ...prev,
-      createClientMessage({ id: userMessageId, role: "user", content, parts: userParts }),
-      createClientMessage({
-        id: assistantMessageId,
-        role: "assistant",
-        content: "",
-        parts: [],
-        isStreaming: true,
-      }),
-    ])
-
-    const controller = new AbortController()
-    streamAbortRef.current = controller
-
-    try {
-      const response = await fetch(
-        `/api/conversations/${conversationId}/sessions/${sessionId}/chat/stream`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ content, parts: userParts }),
-          signal: controller.signal,
-        }
-      )
-      if (!response.ok || !response.body) {
-        throw new Error("Failed to start streaming response.")
-      }
-
-      const reader = response.body.getReader()
-      const decoder = new TextDecoder()
-      let buffer = ""
-
-      while (true) {
-        const { done, value } = await reader.read()
-        if (done) {
-          break
-        }
-        buffer += decoder.decode(value, { stream: true })
-        const parts = buffer.split("\n\n")
-        buffer = parts.pop() ?? ""
-
-        for (const part of parts) {
-          const lines = part.split("\n").filter(Boolean)
-          if (!lines.length) {
-            continue
-          }
-          let eventName = "message"
-          const dataLines: string[] = []
-          for (const line of lines) {
-            if (line.startsWith("event:")) {
-              eventName = line.replace(/^event:\s*/, "")
-            } else if (line.startsWith("data:")) {
-              dataLines.push(line.replace(/^data:\s*/, ""))
-            }
-          }
-          const rawData = dataLines.join("\n")
-          let data: any = rawData
-          if (rawData) {
-            try {
-              data = JSON.parse(rawData)
-            } catch {
-              data = rawData
-            }
-          }
-
-          if (eventName === "message_delta" && typeof data?.delta === "string") {
-            setIsAwaitingFirstToken(false)
-            setMessages((prev) =>
-              prev.map((message) =>
-                message.id === assistantMessageId
-                  ? applyMessageDelta(message, data.delta)
-                  : message
-              )
-            )
-            continue
-          }
-
-          if (eventName === "message_part_updated" || eventName === "message.part.updated") {
-            const incomingPart = data?.part
-            if (incomingPart && typeof incomingPart.type === "string") {
-              setIsAwaitingFirstToken(false)
-              setMessages((prev) =>
-                prev.map((message) => {
-                  if (message.id !== assistantMessageId) {
-                    return message
-                  }
-                  return applyMessagePartUpdate(
-                    message,
-                    incomingPart as StructuredMessagePart,
-                    data?.delta
-                  )
-                })
-              )
-            }
-            continue
-          }
-
-          if (eventName === "message_end") {
-            setIsAwaitingFirstToken(false)
-            setChatStatus("idle")
-            setMessages((prev) =>
-              prev.map((message) =>
-                message.id === assistantMessageId
-                  ? applyMessageEnd(message, {
-                      content: typeof data?.content === "string" ? data.content : undefined,
-                      parts: Array.isArray(data?.parts) ? data.parts : undefined,
-                    })
-                  : message
-              )
-            )
-            continue
-          }
-
-          if (eventName === "error") {
-            setIsAwaitingFirstToken(false)
-            setChatStatus("error")
-            setChatError(
-              typeof data?.message === "string"
-                ? data.message
-                : "Streaming failed."
-            )
-            setMessages((prev) =>
-              prev.map((message) =>
-                message.id === assistantMessageId
-                  ? { ...message, isStreaming: false }
-                  : message
-              )
-            )
-          }
-        }
-      }
-    } catch (err) {
-      if (controller.signal.aborted) {
-        return
-      }
-      setIsAwaitingFirstToken(false)
-      setChatStatus("error")
-      setChatError(err instanceof Error ? err.message : "Streaming failed.")
-      setMessages((prev) =>
-        prev.map((message) =>
-          message.id === assistantMessageId
-            ? { ...message, isStreaming: false }
-            : message
-        )
-      )
-    } finally {
-      if (!controller.signal.aborted) {
-        setIsAwaitingFirstToken(false)
-        setChatStatus((status) => (status === "streaming" ? "idle" : status))
-        setMessages((prev) =>
-          prev.map((message) =>
-            message.id === assistantMessageId
-              ? { ...message, isStreaming: false }
-              : message
-          )
-        )
-      }
-      streamAbortRef.current = null
-    }
-  }
-
-  const handleCopyMessage = React.useCallback(
-    async (messageId: string, text: string) => {
-      const trimmed = text.trim()
-      if (!trimmed) {
-        return
-      }
-
-      try {
-        if (navigator.clipboard?.writeText) {
-          await navigator.clipboard.writeText(trimmed)
-        } else {
-          const textarea = document.createElement("textarea")
-          textarea.value = trimmed
-          textarea.style.position = "fixed"
-          textarea.style.opacity = "0"
-          document.body.appendChild(textarea)
-          textarea.select()
-          document.execCommand("copy")
-          document.body.removeChild(textarea)
-        }
-      } catch {
-        return
-      }
-
-      setCopiedMessageId(messageId)
-      if (copyTimeoutRef.current !== null) {
-        window.clearTimeout(copyTimeoutRef.current)
-      }
-      copyTimeoutRef.current = window.setTimeout(() => {
-        setCopiedMessageId((current) => (current === messageId ? null : current))
-      }, 2000)
-    },
-    [setCopiedMessageId]
-  )
-
-  const handleRetryMessage = React.useCallback(
-    (messageIndex: number) => {
-      if (chatStatus === "streaming") {
-        return
-      }
-
-      for (let index = messageIndex; index >= 0; index -= 1) {
-        const candidate = messages[index]
-        if (candidate?.role !== "user") {
-          continue
-        }
-        const candidateText =
-          getTextFromParts(candidate.parts) || candidate.content || ""
-        if (candidateText.trim()) {
-          void handlePromptSubmit({ text: candidateText, files: [] })
-          return
-        }
-      }
-    },
-    [chatStatus, messages, handlePromptSubmit]
-  )
-
-  const handleRestoreCheckpoint = React.useCallback(
-    async (checkpoint: CheckpointMarker) => {
-      if (!selectedWorkspace || !selectedChat) {
-        return
-      }
-      if (!checkpoint.restore) {
-        return
-      }
-      if (restoringCheckpoints[checkpoint.id]) {
-        return
-      }
-      setRestoreCheckpointError(null)
-      setRestoringCheckpoints((prev) => ({ ...prev, [checkpoint.id]: true }))
-      try {
-        let response: Response
-        if (checkpoint.restore.url) {
-          const method = (checkpoint.restore.method ?? "POST").toUpperCase()
-          const hasBody = checkpoint.restore.payload !== undefined && method !== "GET"
-          response = await fetch(checkpoint.restore.url, {
-            method,
-            headers: hasBody ? { "Content-Type": "application/json" } : undefined,
-            body: hasBody ? JSON.stringify(checkpoint.restore.payload) : undefined,
-          })
-        } else {
-          if (!checkpoint.restore.messageId) {
-            throw new Error("Checkpoint restore is missing a message id.")
-          }
-          response = await fetch(
-            `/api/conversations/${selectedWorkspace.id}/sessions/${selectedChat.id}/checkpoints/restore`,
-            {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                messageId: checkpoint.restore.messageId,
-                partId: checkpoint.restore.partId,
-              }),
-            }
-          )
-        }
-        if (!response.ok) {
-          let message = "Failed to restore checkpoint."
-          try {
-            const payload = (await response.json()) as { error?: string }
-            if (payload.error) {
-              message = payload.error
-            }
-          } catch {
-            // Ignore parsing errors
-          }
-          throw new Error(message)
-        }
-        await loadTranscript(false)
-      } catch (err) {
-        setRestoreCheckpointError(
-          err instanceof Error ? err.message : "Failed to restore checkpoint."
-        )
-      } finally {
-        setRestoringCheckpoints((prev) => {
-          const next = { ...prev }
-          delete next[checkpoint.id]
-          return next
-        })
-      }
-    },
-    [
-      selectedWorkspace,
-      selectedChat,
-      restoringCheckpoints,
-      loadTranscript,
-      setRestoreCheckpointError,
-    ]
-  )
-
-  const isProjectView = Boolean(
-    !isSettingsView &&
-      selectedProject &&
-      !selectedWorkspace &&
-      !selectedChat &&
-      !isProjectsView
-  )
-  const isWorkspaceView = Boolean(!isSettingsView && selectedWorkspace && !selectedChat)
-  const isChatView = Boolean(!isSettingsView && selectedChat)
-  const settingsDefaultProvider = settingsForm.modelProviders.find(
-    (provider) => provider.id === settingsForm.defaultProvider
-  )
-  const settingsDefaultModels = settingsDefaultProvider?.models ?? []
-  const isChatStreaming = chatStatus === "streaming"
   const projectIconValue = selectedProject?.icon?.trim() ?? ""
-  const promptDisabled =
-    isChatStreaming || !selectedWorkspace || !selectedChat || isTranscriptLoading
   const nextThemeLabel = theme === "dark" ? "Light" : "Dark"
+  const {
+    viewLabel,
+    viewTitle,
+    viewDescription,
+    secondaryTitle,
+    secondaryItems,
+    projectRepoLabel,
+    projectRepoHref,
+    recentSessionsForView,
+    mainView,
+    contentVariant,
+  } = useWorkbenchViewModel({
+    projects,
+    isLoading,
+    error,
+    selectedProject,
+    selectedWorkspace,
+    selectedChat,
+    isProjectsView,
+    isSettingsView,
+    isProjectView,
+    isWorkspaceView,
+    isChatView,
+    recentSessions,
+    projectRecentSessions,
+  })
 
-  const viewLabel = isSettingsView
-    ? "Settings"
-    : isChatView
-      ? "Chat Session"
-      : isWorkspaceView
-        ? "Workspace"
-        : isProjectView
-          ? "Project"
-          : "Home"
-  const viewTitle = isSettingsView
-    ? "Settings"
-    : isProjectsView
-      ? "Home"
-      : selectedChat?.name ??
-        selectedWorkspace?.name ??
-        selectedProject?.name ??
-        (isLoading ? "Syncing projects" : "Choose a project")
-  const viewDescription = isSettingsView
-    ? "Manage access tokens and appearance for Maestro."
-    : isProjectsView
-      ? "Home for your projects, new work, and recent workspaces."
-      : selectedChat
-        ? `Workspace in ${selectedWorkspace?.name ?? "workspace"}.`
-        : selectedWorkspace
-          ? "Workspace activity, members, and recent sessions."
-          : selectedProject
-            ? `Repo: ${selectedProject.repoUrl?.trim() || selectedProject.repoPath}`
-            : isLoading
-              ? "Fetching projects, workspaces, and sessions."
-              : error
-                ? error
-                : "Select a project to explore its workspaces."
-
-  const secondaryTitle = isChatView
-    ? "Workspace context"
-    : isWorkspaceView
-      ? "Chat sessions"
-      : isProjectView
-        ? "Workspaces"
-        : "Projects"
-  const secondaryItems = isLoading
-    ? ["Loading projects..."]
-    : error
-      ? ["Unable to load projects."]
-      : isChatView
-        ? [
-            selectedProject?.name ?? "",
-            selectedWorkspace?.name ?? "",
-          ].filter(Boolean)
-        : isWorkspaceView
-          ? selectedWorkspace?.chats.map((chat) => chat.name) ?? []
-          : isProjectView
-            ? selectedProject?.workspaces.map((workspace) => workspace.name) ?? []
-            : projects.map((project) => project.name)
-  const showWorkspaceCreator = Boolean(isProjectView && selectedProject)
-  const projectRepoLabel = selectedProject?.repoUrl?.trim() || selectedProject?.repoPath
-  const projectRepoHref =
-    selectedProject?.repoUrl?.trim() && selectedProject.repoUrl.trim().startsWith("http")
-      ? selectedProject.repoUrl.trim()
-      : null
-  const recentSessionsForView = isProjectView ? projectRecentSessions : recentSessions
   return (
-    <SidebarProvider>
-        <AppSidebar
+    <WorkbenchLayout
+      sidebar={
+        <WorkbenchSidebarSection
           projects={projects}
           isProjectsView={isProjectsView}
           isSettingsView={isSettingsView}
           selectedProjectId={selectedProjectId}
           selectedWorkspaceId={selectedWorkspaceId}
           selectedChatId={selectedChatId}
-          onSelectProjects={handleSelectProjectsView}
-          onSelectSettings={handleSelectSettingsView}
-          onSelectProject={handleSelectProject}
-          onSelectWorkspace={handleSelectWorkspace}
-          onSelectChat={handleSelectChat}
+          onSelectProjects={actions.selectProjectsView}
+          onSelectSettings={actions.selectSettingsView}
+          onSelectProject={actions.selectProject}
+          onSelectWorkspace={actions.selectWorkspace}
+          onSelectChat={actions.selectChat}
         />
-      <SidebarRail />
-      <SidebarInset>
-        <WorkbenchHeader
+      }
+      header={
+        <WorkbenchHeaderSection
           isSettingsView={isSettingsView}
           isLoading={isLoading}
           selectedProject={selectedProject}
           selectedWorkspace={selectedWorkspace}
           selectedChat={selectedChat}
-          onSelectProjectsView={handleSelectProjectsView}
-          onSelectProject={handleSelectProject}
-          onSelectWorkspace={handleSelectWorkspace}
+          onSelectProjectsView={actions.selectProjectsView}
+          onSelectProject={actions.selectProject}
+          onSelectWorkspace={actions.selectWorkspace}
         />
-        {isSettingsView ? (
-          <SettingsView
-            settingsForm={settingsForm}
-            settingsDefaultModels={settingsDefaultModels}
-            settingsError={settingsError}
-            settingsSavedMessage={settingsSavedMessage}
-            isSavingSettings={isSavingSettings}
+      }
+    >
+      <WorkbenchContent
+        variant={contentVariant}
+        settings={
+          <SettingsViewSection
+            settings={settings}
             theme={theme}
             nextThemeLabel={nextThemeLabel}
             onToggleTheme={toggleTheme}
-            onSettingsSubmit={handleSettingsSubmit}
-            onSettingsChange={handleSettingsChange}
-            updateModelProvider={updateModelProvider}
-            onAddProvider={handleAddProvider}
-            onRemoveProvider={handleRemoveProvider}
-            onAddModel={handleAddModel}
-            onRemoveModel={handleRemoveModel}
-            onDefaultProviderChange={handleDefaultProviderChange}
-            onDefaultModelChange={handleDefaultModelChange}
           />
-        ) : (
-          <div className="flex flex-1 flex-col gap-4 p-6">
-            <WorkbenchOverview
-              isProjectView={isProjectView}
-              isWorkspaceView={isWorkspaceView}
+        }
+      >
+        <WorkbenchOverview
+          isProjectView={isProjectView}
+          isWorkspaceView={isWorkspaceView}
+          selectedProject={selectedProject}
+          selectedWorkspace={selectedWorkspace}
+          projectIconValue={projectIconValue}
+          viewLabel={viewLabel}
+          viewTitle={viewTitle}
+          viewDescription={viewDescription}
+          projectRepoLabel={projectRepoLabel}
+          projectRepoHref={projectRepoHref}
+          deletingWorkspace={deletingWorkspace}
+          deleteWorkspaceErrors={deleteWorkspaceErrors}
+          recentSessionsLimit={recentSessionsLimit}
+          recentSessionsForView={recentSessionsForView}
+          formatDateTime={formatDateTime}
+          onDeleteWorkspace={(workspaceId, workspaceName) =>
+            void onConfirmDeleteWorkspace(workspaceId, workspaceName)
+          }
+          onSelectChat={actions.selectChat}
+        />
+        <WorkbenchMain
+          view={mainView}
+          projects={
+            <ProjectsViewSection
+              data={{
+                projectForm,
+                createProjectError,
+                isCreatingProject,
+                isSelectingDirectory,
+                allWorkspaces,
+                projects,
+                isLoading,
+                error,
+                sortedPullRequests,
+                hasRepoProjects,
+                isLoadingPullRequests,
+                pullRequestsError,
+              }}
+              formatting={{
+                formatDate,
+                formatDateTime,
+              }}
+              actions={{
+                onCreateProject: (event) => void onCreateProject(event),
+                onProjectFormChange,
+                onSelectDirectory: () => void onSelectDirectory(),
+                onSelectWorkspace: actions.selectWorkspace,
+                onSelectProject: actions.selectProject,
+              }}
+            />
+          }
+          project={
+            <ProjectWorkspacesSection
               selectedProject={selectedProject}
-              selectedWorkspace={selectedWorkspace}
-              projectIconValue={projectIconValue}
-              viewLabel={viewLabel}
-              viewTitle={viewTitle}
-              viewDescription={viewDescription}
-              projectRepoLabel={projectRepoLabel}
-              projectRepoHref={projectRepoHref}
+              projectPullRequests={projectPullRequests}
+              isLoadingPullRequests={isLoadingPullRequests}
+              pullRequestsError={pullRequestsError}
+              workspaceTitle={workspaceForm.title}
+              isCreatingWorkspace={isCreatingWorkspace}
+              createWorkspaceError={createWorkspaceError}
+              mergedPullRequests={mergedPullRequests}
+              mergingPullRequests={mergingPullRequests}
+              mergePullRequestErrors={mergePullRequestErrors}
+              deletingMergeWorkspace={deletingMergeWorkspace}
+              deleteMergeWorkspaceErrors={deleteMergeWorkspaceErrors}
               deletingWorkspace={deletingWorkspace}
               deleteWorkspaceErrors={deleteWorkspaceErrors}
-              recentSessionsLimit={recentSessionsLimit}
-              recentSessionsForView={recentSessionsForView}
               formatDateTime={formatDateTime}
-              onDeleteWorkspace={(workspaceId, workspaceName) =>
-                void handleConfirmDeleteWorkspace(workspaceId, workspaceName)
+              onSelectWorkspace={actions.selectWorkspace}
+              onCreateWorkspace={(event) => void onCreateWorkspace(event)}
+              onWorkspaceTitleChange={onWorkspaceFormChange}
+              onMergePullRequest={(item) => void onMergePullRequest(item)}
+              onDeleteMergedWorkspace={(pullRequestKey, workspaceId, workspaceName) =>
+                void onDeleteMergedWorkspace(pullRequestKey, workspaceId, workspaceName)
               }
-              onSelectChat={handleSelectChat}
+              onDeleteWorkspace={onDeleteWorkspace}
+              getPullRequestKey={getPullRequestKey}
             />
-            {isProjectsView ? (
-              <ProjectsView
-                projectForm={projectForm}
-                createProjectError={createProjectError}
-                isCreatingProject={isCreatingProject}
-                isSelectingDirectory={isSelectingDirectory}
-                allWorkspaces={allWorkspaces}
-                projects={projects}
-                isLoading={isLoading}
-                error={error}
-                sortedPullRequests={sortedPullRequests}
-                hasRepoProjects={hasRepoProjects}
-                isLoadingPullRequests={isLoadingPullRequests}
-                pullRequestsError={pullRequestsError}
-                formatDate={formatDate}
-                formatDateTime={formatDateTime}
-                onCreateProject={handleCreateProject}
-                onProjectFormChange={handleProjectFormChange}
-                onSelectDirectory={() => void handleSelectDirectory()}
-                onSelectWorkspace={handleSelectWorkspace}
-                onSelectProject={handleSelectProject}
-              />
-            ) : showWorkspaceCreator ? (
-              selectedProject ? (
-                <ProjectWorkspacesTable
-                  projectId={selectedProject.id}
-                  projectName={selectedProject.name}
-                  workspaces={selectedProject.workspaces}
-                  pullRequests={projectPullRequests}
-                  isLoadingPullRequests={isLoadingPullRequests}
-                  pullRequestsError={pullRequestsError}
-                  onSelectWorkspace={handleSelectWorkspace}
-                  onCreateWorkspace={handleCreateWorkspace}
-                  workspaceTitle={workspaceForm.title}
-                  onWorkspaceTitleChange={handleWorkspaceFormChange}
-                  isCreatingWorkspace={isCreatingWorkspace}
-                  createWorkspaceError={createWorkspaceError}
-                  formatDateTime={formatDateTime}
-                  onMergePullRequest={handleMergePullRequest}
-                  mergedPullRequests={mergedPullRequests}
-                  mergingPullRequests={mergingPullRequests}
-                  mergePullRequestErrors={mergePullRequestErrors}
-                  onDeleteMergedWorkspace={handleDeleteMergedWorkspace}
-                  deletingMergeWorkspace={deletingMergeWorkspace}
-                  deleteMergeWorkspaceErrors={deleteMergeWorkspaceErrors}
-                  onDeleteWorkspace={handleDeleteWorkspace}
-                  deletingWorkspace={deletingWorkspace}
-                  deleteWorkspaceErrors={deleteWorkspaceErrors}
-                  getPullRequestKey={getPullRequestKey}
-                />
-              ) : null
-            ) : isWorkspaceView ? (
-              <WorkspaceSessionsView
-                selectedProject={selectedProject}
-                selectedWorkspace={selectedWorkspace}
-                createSessionError={createSessionError}
-                isCreatingSession={isCreatingSession}
-                deletingSessionId={deletingSessionId}
-                deleteSessionError={deleteSessionError}
-                onCreateSession={handleCreateSession}
-                onDeleteSession={handleDeleteSession}
-                onSelectChat={handleSelectChat}
-              />
-            ) : isChatView ? (
-              <ChatView
-                isTranscriptLoading={isTranscriptLoading}
-                messages={messages}
-                copiedMessageId={copiedMessageId}
-                isChatStreaming={isChatStreaming}
-                isAwaitingFirstToken={isAwaitingFirstToken}
-                restoringCheckpoints={restoringCheckpoints}
-                emptyStateSuggestions={emptyStateSuggestions}
-                promptDisabled={promptDisabled}
-                promptValue={promptValue}
-                modelOptions={modelOptions}
-                selectedModel={selectedModel}
-                isUpdatingModel={isUpdatingModel}
-                contextUsage={contextUsage}
-                updateModelError={updateModelError}
-                chatError={chatError}
-                restoreCheckpointError={restoreCheckpointError}
-                onSuggestionClick={handleSuggestionClick}
-                onPromptSubmit={handlePromptSubmit}
-                onPromptChange={handlePromptChange}
-                onUpdateSessionModel={handleUpdateSessionModel}
-                onCopyMessage={handleCopyMessage}
-                onRetryMessage={handleRetryMessage}
-                onRestoreCheckpoint={handleRestoreCheckpoint}
-              />
-            ) : (
-              <SecondaryItemsView
-                title={secondaryTitle}
-                items={secondaryItems}
-              />
-            )}
-          </div>
-        )}
-      </SidebarInset>
-    </SidebarProvider>
+          }
+          workspace={
+            <WorkspaceSessionsSection
+              selectedProject={selectedProject}
+              selectedWorkspace={selectedWorkspace}
+              createSessionError={createSessionError}
+              isCreatingSession={isCreatingSession}
+              deletingSessionId={deletingSessionId}
+              deleteSessionError={deleteSessionError}
+              onCreateSession={(event) => void onCreateSession(event)}
+              onDeleteSession={(sessionId) => void onDeleteSession(sessionId)}
+              onSelectChat={actions.selectChat}
+            />
+          }
+          chat={
+            <ChatViewSection
+              isTranscriptLoading={chat.isTranscriptLoading}
+              messages={chat.messages}
+              copiedMessageId={chat.copiedMessageId}
+              isChatStreaming={chat.isChatStreaming}
+              isAwaitingFirstToken={chat.isAwaitingFirstToken}
+              restoringCheckpoints={chat.restoringCheckpoints}
+              emptyStateSuggestions={emptyStateSuggestions}
+              promptDisabled={chat.promptDisabled}
+              promptValue={chat.promptValue}
+              modelOptions={modelOptions}
+              selectedModel={selectedModel}
+              isUpdatingModel={isUpdatingModel}
+              contextUsage={chat.contextUsage}
+              updateModelError={updateModelError}
+              chatError={chat.chatError}
+              restoreCheckpointError={chat.restoreCheckpointError}
+              onSuggestionClick={chat.onSuggestionClick}
+              onPromptSubmit={chat.onPromptSubmit}
+              onPromptChange={chat.onPromptChange}
+              onUpdateSessionModel={onUpdateSessionModel}
+              onCopyMessage={chat.onCopyMessage}
+              onRetryMessage={chat.onRetryMessage}
+              onRestoreCheckpoint={chat.onRestoreCheckpoint}
+            />
+          }
+          secondary={<SecondaryItemsView title={secondaryTitle} items={secondaryItems} />}
+        />
+      </WorkbenchContent>
+    </WorkbenchLayout>
+  )
+}
+
+const App = () => {
+  return (
+    <WorkbenchProvider>
+      <WorkbenchShell />
+    </WorkbenchProvider>
   )
 }
 

--- a/apps/web/src/features/workbench/README.md
+++ b/apps/web/src/features/workbench/README.md
@@ -1,0 +1,56 @@
+# Workbench Architecture
+
+The workbench feature is composed from provider state, controller hooks, view-model hooks, and presentational views.
+
+## Composition root
+
+- `apps/web/src/App.tsx` is the composition root.
+- `App` mounts `WorkbenchProvider` and `WorkbenchShell`.
+- `WorkbenchShell` wires controllers, selectors, and section components.
+
+## State boundary
+
+- `apps/web/src/features/workbench/workbench-context.tsx` owns global workbench state:
+  - project loading and selection sync
+  - selected project/workspace/chat IDs
+  - derived view state (`isProjectsView`, `isProjectView`, etc.)
+- `useWorkbench()` exposes `state`, `actions`, and `meta`.
+
+## Controllers (feature logic)
+
+- `apps/web/src/features/workbench/hooks/use-settings-controller.tsx`
+  - settings load/save
+  - model provider/default model management
+  - `/api/models` catalog sync
+- `apps/web/src/features/workbench/hooks/use-chat-controller.tsx`
+  - transcript loading
+  - streaming chat state
+  - checkpoint restore and prompt submission
+- `apps/web/src/features/workbench/hooks/use-projects-controller.tsx`
+  - project/workspace/session CRUD flows
+  - session model updates
+- `apps/web/src/features/workbench/hooks/use-pull-requests-controller.tsx`
+  - pull request loading, merge action, and post-merge workspace cleanup
+
+## View-model hooks
+
+- `apps/web/src/features/workbench/hooks/use-workbench-view-model.tsx`
+  - derives labels, titles, descriptions, and main/secondary view variants
+- `apps/web/src/features/workbench/hooks/use-chat-model-options.tsx`
+  - derives chat model options from settings + selected session
+
+## Rendering layers
+
+- `apps/web/src/features/workbench/components/*-section.tsx`
+  - section-level composition wrappers for sidebar/header/settings/projects/workspaces/chat
+- `apps/web/src/features/workbench/views/*.tsx`
+  - presentational feature views
+- `apps/web/src/features/workbench/components/workbench-layout.tsx`,
+  `apps/web/src/features/workbench/components/workbench-content.tsx`, and
+  `apps/web/src/features/workbench/components/workbench-main.tsx`
+  - top-level layout and explicit view variants
+
+## Message part mapping
+
+- Structured message mapping lives in `apps/web/src/features/workbench/message-entries.ts`.
+- Chat rendering consumes mapped entries in `apps/web/src/features/workbench/views/chat-view.tsx`.

--- a/apps/web/src/features/workbench/components/chat-view-section.tsx
+++ b/apps/web/src/features/workbench/components/chat-view-section.tsx
@@ -1,0 +1,35 @@
+import { ChatView } from "../views/chat-view"
+import type { ContextUsage } from "../../../components/ai-elements/context-usage"
+import type { ModelOption } from "../../../components/ai-elements/model-selector"
+import type { PromptInputMessage } from "../../../components/ai-elements/prompt-input"
+import type { ChatMessage, CheckpointMarker } from "../types"
+
+type ChatViewSectionProps = {
+  isTranscriptLoading: boolean
+  messages: ChatMessage[]
+  copiedMessageId: string | null
+  isChatStreaming: boolean
+  isAwaitingFirstToken: boolean
+  restoringCheckpoints: Record<string, boolean>
+  emptyStateSuggestions: string[]
+  promptDisabled: boolean
+  promptValue: string
+  modelOptions: ModelOption[]
+  selectedModel: string
+  isUpdatingModel: boolean
+  contextUsage?: ContextUsage
+  updateModelError: string | null
+  chatError: string | null
+  restoreCheckpointError: string | null
+  onSuggestionClick: (suggestion: string) => void
+  onPromptSubmit: (message: PromptInputMessage) => Promise<void>
+  onPromptChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void
+  onUpdateSessionModel: (modelId: string) => Promise<void>
+  onCopyMessage: (messageId: string, messageText: string) => Promise<void>
+  onRetryMessage: (messageIndex: number) => void
+  onRestoreCheckpoint: (checkpoint: CheckpointMarker) => Promise<void>
+}
+
+export const ChatViewSection = (props: ChatViewSectionProps) => {
+  return <ChatView {...props} />
+}

--- a/apps/web/src/features/workbench/components/project-workspaces-section.tsx
+++ b/apps/web/src/features/workbench/components/project-workspaces-section.tsx
@@ -1,0 +1,92 @@
+import { ProjectWorkspacesTable } from "../../../components/project-workspaces-table"
+import type { OpenPullRequest, Project } from "../types"
+
+type ProjectWorkspacesSectionProps = {
+  selectedProject: Project | null
+  projectPullRequests: OpenPullRequest[]
+  isLoadingPullRequests: boolean
+  pullRequestsError: string | null
+  workspaceTitle: string
+  isCreatingWorkspace: boolean
+  createWorkspaceError: string | null
+  mergedPullRequests: Record<
+    string,
+    { workspaceId?: string; workspaceName?: string; workspaceDeleted?: boolean }
+  >
+  mergingPullRequests: Record<string, boolean>
+  mergePullRequestErrors: Record<string, string>
+  deletingMergeWorkspace: Record<string, boolean>
+  deleteMergeWorkspaceErrors: Record<string, string>
+  deletingWorkspace: Record<string, boolean>
+  deleteWorkspaceErrors: Record<string, string>
+  formatDateTime: (value?: string) => string
+  onSelectWorkspace: (projectId: string, workspaceId: string) => void
+  onCreateWorkspace: (event: React.FormEvent<HTMLFormElement>) => void
+  onWorkspaceTitleChange: (event: React.ChangeEvent<HTMLInputElement>) => void
+  onMergePullRequest: (item: OpenPullRequest) => void
+  onDeleteMergedWorkspace: (
+    pullRequestKey: string,
+    workspaceId: string,
+    workspaceName?: string
+  ) => void
+  onDeleteWorkspace: (workspaceId: string, workspaceName?: string) => Promise<boolean>
+  getPullRequestKey: (item: OpenPullRequest) => string
+}
+
+export const ProjectWorkspacesSection = ({
+  selectedProject,
+  projectPullRequests,
+  isLoadingPullRequests,
+  pullRequestsError,
+  workspaceTitle,
+  isCreatingWorkspace,
+  createWorkspaceError,
+  mergedPullRequests,
+  mergingPullRequests,
+  mergePullRequestErrors,
+  deletingMergeWorkspace,
+  deleteMergeWorkspaceErrors,
+  deletingWorkspace,
+  deleteWorkspaceErrors,
+  formatDateTime,
+  onSelectWorkspace,
+  onCreateWorkspace,
+  onWorkspaceTitleChange,
+  onMergePullRequest,
+  onDeleteMergedWorkspace,
+  onDeleteWorkspace,
+  getPullRequestKey,
+}: ProjectWorkspacesSectionProps) => {
+  if (!selectedProject) {
+    return null
+  }
+
+  return (
+    <ProjectWorkspacesTable
+      projectId={selectedProject.id}
+      projectName={selectedProject.name}
+      workspaces={selectedProject.workspaces}
+      pullRequests={projectPullRequests}
+      isLoadingPullRequests={isLoadingPullRequests}
+      pullRequestsError={pullRequestsError}
+      onSelectWorkspace={onSelectWorkspace}
+      onCreateWorkspace={onCreateWorkspace}
+      workspaceTitle={workspaceTitle}
+      onWorkspaceTitleChange={onWorkspaceTitleChange}
+      isCreatingWorkspace={isCreatingWorkspace}
+      createWorkspaceError={createWorkspaceError}
+      formatDateTime={formatDateTime}
+      onMergePullRequest={onMergePullRequest}
+      mergedPullRequests={mergedPullRequests}
+      mergingPullRequests={mergingPullRequests}
+      mergePullRequestErrors={mergePullRequestErrors}
+      onDeleteMergedWorkspace={onDeleteMergedWorkspace}
+      deletingMergeWorkspace={deletingMergeWorkspace}
+      deleteMergeWorkspaceErrors={deleteMergeWorkspaceErrors}
+      onDeleteWorkspace={onDeleteWorkspace}
+      deletingWorkspace={deletingWorkspace}
+      deleteWorkspaceErrors={deleteWorkspaceErrors}
+      getPullRequestKey={getPullRequestKey}
+    />
+  )
+}

--- a/apps/web/src/features/workbench/components/projects-view-section.tsx
+++ b/apps/web/src/features/workbench/components/projects-view-section.tsx
@@ -1,0 +1,67 @@
+import { ProjectsView } from "../views/projects-view"
+import type {
+  OpenPullRequest,
+  Project,
+  ProjectFormState,
+  WorkspaceSummary,
+} from "../types"
+
+type ProjectsViewSectionProps = {
+  data: {
+    projectForm: ProjectFormState
+    createProjectError: string | null
+    isCreatingProject: boolean
+    isSelectingDirectory: boolean
+    allWorkspaces: WorkspaceSummary[]
+    projects: Project[]
+    isLoading: boolean
+    error: string | null
+    sortedPullRequests: OpenPullRequest[]
+    hasRepoProjects: boolean
+    isLoadingPullRequests: boolean
+    pullRequestsError: string | null
+  }
+  formatting: {
+    formatDate: (value?: string) => string
+    formatDateTime: (value?: string) => string
+  }
+  actions: {
+    onCreateProject: (event: React.FormEvent<HTMLFormElement>) => void
+    onProjectFormChange: (
+      field: keyof ProjectFormState
+    ) => (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => void
+    onSelectDirectory: () => void
+    onSelectWorkspace: (projectId: string, workspaceId: string) => void
+    onSelectProject: (projectId: string) => void
+  }
+}
+
+export const ProjectsViewSection = ({
+  data,
+  formatting,
+  actions,
+}: ProjectsViewSectionProps) => {
+  return (
+    <ProjectsView
+      projectForm={data.projectForm}
+      createProjectError={data.createProjectError}
+      isCreatingProject={data.isCreatingProject}
+      isSelectingDirectory={data.isSelectingDirectory}
+      allWorkspaces={data.allWorkspaces}
+      projects={data.projects}
+      isLoading={data.isLoading}
+      error={data.error}
+      sortedPullRequests={data.sortedPullRequests}
+      hasRepoProjects={data.hasRepoProjects}
+      isLoadingPullRequests={data.isLoadingPullRequests}
+      pullRequestsError={data.pullRequestsError}
+      formatDate={formatting.formatDate}
+      formatDateTime={formatting.formatDateTime}
+      onCreateProject={actions.onCreateProject}
+      onProjectFormChange={actions.onProjectFormChange}
+      onSelectDirectory={actions.onSelectDirectory}
+      onSelectWorkspace={actions.onSelectWorkspace}
+      onSelectProject={actions.onSelectProject}
+    />
+  )
+}

--- a/apps/web/src/features/workbench/components/settings-view-section.tsx
+++ b/apps/web/src/features/workbench/components/settings-view-section.tsx
@@ -1,0 +1,38 @@
+import { SettingsView } from "../views/settings-view"
+import type { SettingsController } from "../hooks/use-settings-controller"
+
+type SettingsViewSectionProps = {
+  settings: SettingsController
+  theme: "light" | "dark"
+  nextThemeLabel: string
+  onToggleTheme: () => void
+}
+
+export const SettingsViewSection = ({
+  settings,
+  theme,
+  nextThemeLabel,
+  onToggleTheme,
+}: SettingsViewSectionProps) => {
+  return (
+    <SettingsView
+      settingsForm={settings.settingsForm}
+      settingsDefaultModels={settings.settingsDefaultModels}
+      settingsError={settings.settingsError}
+      settingsSavedMessage={settings.settingsSavedMessage}
+      isSavingSettings={settings.isSavingSettings}
+      theme={theme}
+      nextThemeLabel={nextThemeLabel}
+      onToggleTheme={onToggleTheme}
+      onSettingsSubmit={settings.onSettingsSubmit}
+      onSettingsChange={settings.onSettingsChange}
+      updateModelProvider={settings.updateModelProvider}
+      onAddProvider={settings.onAddProvider}
+      onRemoveProvider={settings.onRemoveProvider}
+      onAddModel={settings.onAddModel}
+      onRemoveModel={settings.onRemoveModel}
+      onDefaultProviderChange={settings.onDefaultProviderChange}
+      onDefaultModelChange={settings.onDefaultModelChange}
+    />
+  )
+}

--- a/apps/web/src/features/workbench/components/workbench-content.tsx
+++ b/apps/web/src/features/workbench/components/workbench-content.tsx
@@ -1,0 +1,15 @@
+import * as React from "react"
+
+type WorkbenchContentProps = {
+  variant: "settings" | "main"
+  settings: React.ReactNode
+  children: React.ReactNode
+}
+
+export const WorkbenchContent = ({ variant, settings, children }: WorkbenchContentProps) => {
+  if (variant === "settings") {
+    return <>{settings}</>
+  }
+
+  return <div className="flex flex-1 flex-col gap-4 p-6">{children}</div>
+}

--- a/apps/web/src/features/workbench/components/workbench-header-section.tsx
+++ b/apps/web/src/features/workbench/components/workbench-header-section.tsx
@@ -1,0 +1,37 @@
+import { WorkbenchHeader } from "../views/workbench-header"
+import type { Project, Workspace } from "../types"
+
+type WorkbenchHeaderSectionProps = {
+  isSettingsView: boolean
+  isLoading: boolean
+  selectedProject: Project | null
+  selectedWorkspace: Workspace | null
+  selectedChat: { id: string; name: string; model?: string } | null
+  onSelectProjectsView: () => void
+  onSelectProject: (projectId: string) => void
+  onSelectWorkspace: (projectId: string, workspaceId: string) => void
+}
+
+export const WorkbenchHeaderSection = ({
+  isSettingsView,
+  isLoading,
+  selectedProject,
+  selectedWorkspace,
+  selectedChat,
+  onSelectProjectsView,
+  onSelectProject,
+  onSelectWorkspace,
+}: WorkbenchHeaderSectionProps) => {
+  return (
+    <WorkbenchHeader
+      isSettingsView={isSettingsView}
+      isLoading={isLoading}
+      selectedProject={selectedProject}
+      selectedWorkspace={selectedWorkspace}
+      selectedChat={selectedChat}
+      onSelectProjectsView={onSelectProjectsView}
+      onSelectProject={onSelectProject}
+      onSelectWorkspace={onSelectWorkspace}
+    />
+  )
+}

--- a/apps/web/src/features/workbench/components/workbench-layout.tsx
+++ b/apps/web/src/features/workbench/components/workbench-layout.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { SidebarInset, SidebarProvider, SidebarRail } from "../../../components/ui/sidebar"
+
+type WorkbenchLayoutProps = {
+  sidebar: React.ReactNode
+  header: React.ReactNode
+  children: React.ReactNode
+}
+
+export const WorkbenchLayout = ({ sidebar, header, children }: WorkbenchLayoutProps) => {
+  return (
+    <SidebarProvider>
+      {sidebar}
+      <SidebarRail />
+      <SidebarInset>
+        {header}
+        {children}
+      </SidebarInset>
+    </SidebarProvider>
+  )
+}

--- a/apps/web/src/features/workbench/components/workbench-main.tsx
+++ b/apps/web/src/features/workbench/components/workbench-main.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+
+type WorkbenchMainView = "projects" | "project" | "workspace" | "chat" | "secondary"
+
+type WorkbenchMainProps = {
+  view: WorkbenchMainView
+  projects: React.ReactNode
+  project: React.ReactNode
+  workspace: React.ReactNode
+  chat: React.ReactNode
+  secondary: React.ReactNode
+}
+
+export const WorkbenchMain = ({
+  view,
+  projects,
+  project,
+  workspace,
+  chat,
+  secondary,
+}: WorkbenchMainProps) => {
+  switch (view) {
+    case "projects":
+      return <>{projects}</>
+    case "project":
+      return <>{project}</>
+    case "workspace":
+      return <>{workspace}</>
+    case "chat":
+      return <>{chat}</>
+    case "secondary":
+      return <>{secondary}</>
+    default:
+      return null
+  }
+}

--- a/apps/web/src/features/workbench/components/workbench-overview-header.tsx
+++ b/apps/web/src/features/workbench/components/workbench-overview-header.tsx
@@ -1,0 +1,99 @@
+import { Badge } from "../../../components/ui/badge"
+import { Button } from "../../../components/ui/button"
+import type { Project, Workspace } from "../types"
+
+type WorkbenchOverviewHeaderProps = {
+  isProjectView: boolean
+  isWorkspaceView: boolean
+  selectedProject: Project | null
+  selectedWorkspace: Workspace | null
+  projectIconValue: string
+  viewLabel: string
+  viewTitle: string
+  viewDescription: string
+  projectRepoLabel?: string
+  projectRepoHref?: string | null
+  deletingWorkspace: Record<string, boolean>
+  deleteWorkspaceErrors: Record<string, string>
+  onDeleteWorkspace: (workspaceId: string, workspaceName?: string) => void
+}
+
+export const WorkbenchOverviewHeader = ({
+  isProjectView,
+  isWorkspaceView,
+  selectedProject,
+  selectedWorkspace,
+  projectIconValue,
+  viewLabel,
+  viewTitle,
+  viewDescription,
+  projectRepoLabel,
+  projectRepoHref,
+  deletingWorkspace,
+  deleteWorkspaceErrors,
+  onDeleteWorkspace,
+}: WorkbenchOverviewHeaderProps) => {
+  return (
+    <div className="rounded-xl border bg-card p-6 shadow-sm">
+      <div className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+        {viewLabel}
+      </div>
+      <div className="mt-3 flex flex-wrap items-center gap-3 text-2xl font-semibold text-foreground">
+        {isProjectView && projectIconValue ? (
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted text-lg">
+            {projectIconValue}
+          </div>
+        ) : null}
+        <span>{viewTitle}</span>
+      </div>
+      <div className="mt-2 max-w-2xl text-sm text-muted-foreground">{viewDescription}</div>
+      {isProjectView && selectedProject ? (
+        <div className="mt-3 flex flex-wrap items-center gap-2 text-sm">
+          <span className="text-muted-foreground">Repository</span>
+          {projectRepoHref ? (
+            <a
+              className="font-medium text-primary hover:underline"
+              href={projectRepoHref}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Open repo
+            </a>
+          ) : (
+            <span className="text-foreground">{projectRepoLabel}</span>
+          )}
+          {selectedProject.gitProvider ? (
+            <Badge variant="secondary">
+              {selectedProject.gitProvider === "github" ? "GitHub" : "GitLab"}
+            </Badge>
+          ) : null}
+        </div>
+      ) : null}
+      {isWorkspaceView ? (
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={() =>
+              selectedWorkspace
+                ? onDeleteWorkspace(selectedWorkspace.id, selectedWorkspace.name)
+                : undefined
+            }
+            disabled={
+              selectedWorkspace ? Boolean(deletingWorkspace[selectedWorkspace.id]) : false
+            }
+          >
+            {selectedWorkspace && deletingWorkspace[selectedWorkspace.id]
+              ? "Deleting workspace..."
+              : "Delete workspace"}
+          </Button>
+          {selectedWorkspace && deleteWorkspaceErrors[selectedWorkspace.id] ? (
+            <div className="rounded-md border border-destructive/50 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+              {deleteWorkspaceErrors[selectedWorkspace.id]}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/features/workbench/components/workbench-overview-recent.tsx
+++ b/apps/web/src/features/workbench/components/workbench-overview-recent.tsx
@@ -1,0 +1,56 @@
+import type { RecentSession } from "../types"
+
+type WorkbenchOverviewRecentProps = {
+  isProjectView: boolean
+  recentSessionsLimit: number
+  recentSessionsForView: RecentSession[]
+  formatDateTime: (value?: string) => string
+  onSelectChat: (projectId: string, workspaceId: string, chatId: string) => void
+}
+
+export const WorkbenchOverviewRecent = ({
+  isProjectView,
+  recentSessionsLimit,
+  recentSessionsForView,
+  formatDateTime,
+  onSelectChat,
+}: WorkbenchOverviewRecentProps) => {
+  return (
+    <div className="rounded-xl border bg-background p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <div className="text-sm font-semibold text-foreground">Recent sessions</div>
+          <div className="text-xs text-muted-foreground">
+            {isProjectView
+              ? `Last ${recentSessionsLimit} sessions in this project.`
+              : `Last ${recentSessionsLimit} sessions across your workspaces.`}
+          </div>
+        </div>
+      </div>
+      <div className="mt-4 flex gap-3 overflow-x-auto pb-2">
+        {recentSessionsForView.length ? (
+          recentSessionsForView.map((session) => (
+            <button
+              key={session.id}
+              type="button"
+              onClick={() => onSelectChat(session.projectId, session.workspaceId, session.id)}
+              className="min-w-[220px] rounded-lg border bg-muted/20 px-4 py-3 text-left transition hover:border-primary/60 hover:bg-muted/40"
+            >
+              <div className="text-sm font-semibold text-foreground">{session.name}</div>
+              <div className="mt-1 text-xs text-muted-foreground">
+                {session.projectName} · {session.workspaceName}
+              </div>
+              <div className="mt-2 text-xs text-muted-foreground">
+                Updated {formatDateTime(session.updatedAt)}
+              </div>
+            </button>
+          ))
+        ) : (
+          <div className="rounded-lg border border-dashed px-4 py-3 text-sm text-muted-foreground">
+            No sessions yet. Create a workspace to start chatting.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/features/workbench/components/workbench-sidebar-section.tsx
+++ b/apps/web/src/features/workbench/components/workbench-sidebar-section.tsx
@@ -1,0 +1,46 @@
+import { AppSidebar } from "../../../components/app-sidebar"
+import type { Project } from "../types"
+
+type WorkbenchSidebarSectionProps = {
+  projects: Project[]
+  isProjectsView: boolean
+  isSettingsView: boolean
+  selectedProjectId: string | null
+  selectedWorkspaceId: string | null
+  selectedChatId: string | null
+  onSelectProjects: () => void
+  onSelectSettings: () => void
+  onSelectProject: (projectId: string) => void
+  onSelectWorkspace: (projectId: string, workspaceId: string) => void
+  onSelectChat: (projectId: string, workspaceId: string, chatId: string) => void
+}
+
+export const WorkbenchSidebarSection = ({
+  projects,
+  isProjectsView,
+  isSettingsView,
+  selectedProjectId,
+  selectedWorkspaceId,
+  selectedChatId,
+  onSelectProjects,
+  onSelectSettings,
+  onSelectProject,
+  onSelectWorkspace,
+  onSelectChat,
+}: WorkbenchSidebarSectionProps) => {
+  return (
+    <AppSidebar
+      projects={projects}
+      isProjectsView={isProjectsView}
+      isSettingsView={isSettingsView}
+      selectedProjectId={selectedProjectId}
+      selectedWorkspaceId={selectedWorkspaceId}
+      selectedChatId={selectedChatId}
+      onSelectProjects={onSelectProjects}
+      onSelectSettings={onSelectSettings}
+      onSelectProject={onSelectProject}
+      onSelectWorkspace={onSelectWorkspace}
+      onSelectChat={onSelectChat}
+    />
+  )
+}

--- a/apps/web/src/features/workbench/components/workspace-sessions-section.tsx
+++ b/apps/web/src/features/workbench/components/workspace-sessions-section.tsx
@@ -1,0 +1,40 @@
+import { WorkspaceSessionsView } from "../views/workspace-sessions-view"
+import type { Project, Workspace } from "../types"
+
+type WorkspaceSessionsSectionProps = {
+  selectedProject: Project | null
+  selectedWorkspace: Workspace | null
+  createSessionError: string | null
+  isCreatingSession: boolean
+  deletingSessionId: string | null
+  deleteSessionError: string | null
+  onCreateSession: (event: React.FormEvent<HTMLFormElement>) => void
+  onDeleteSession: (sessionId: string) => void
+  onSelectChat: (projectId: string, workspaceId: string, chatId: string) => void
+}
+
+export const WorkspaceSessionsSection = ({
+  selectedProject,
+  selectedWorkspace,
+  createSessionError,
+  isCreatingSession,
+  deletingSessionId,
+  deleteSessionError,
+  onCreateSession,
+  onDeleteSession,
+  onSelectChat,
+}: WorkspaceSessionsSectionProps) => {
+  return (
+    <WorkspaceSessionsView
+      selectedProject={selectedProject}
+      selectedWorkspace={selectedWorkspace}
+      createSessionError={createSessionError}
+      isCreatingSession={isCreatingSession}
+      deletingSessionId={deletingSessionId}
+      deleteSessionError={deleteSessionError}
+      onCreateSession={onCreateSession}
+      onDeleteSession={onDeleteSession}
+      onSelectChat={onSelectChat}
+    />
+  )
+}

--- a/apps/web/src/features/workbench/hooks/use-chat-controller.tsx
+++ b/apps/web/src/features/workbench/hooks/use-chat-controller.tsx
@@ -1,0 +1,533 @@
+import * as React from "react"
+
+import type { PromptInputMessage } from "../../../components/ai-elements/prompt-input"
+import {
+  applyMessageDelta,
+  applyMessageEnd,
+  applyMessagePartUpdate,
+  createClientMessage,
+  getTextFromParts,
+  normalizeMessageParts,
+  type StructuredMessagePart,
+} from "../../../lib/messages"
+import { extractUsageFromMetadata } from "../message-entries"
+import type { ChatMessage, CheckpointMarker } from "../types"
+import { useWorkbench } from "../workbench-context"
+
+type ChatController = {
+  messages: ChatMessage[]
+  copiedMessageId: string | null
+  chatStatus: "idle" | "streaming" | "error"
+  chatError: string | null
+  restoreCheckpointError: string | null
+  restoringCheckpoints: Record<string, boolean>
+  promptValue: string
+  isTranscriptLoading: boolean
+  isAwaitingFirstToken: boolean
+  isChatStreaming: boolean
+  contextUsage: NonNullable<ReturnType<typeof extractUsageFromMetadata>> | undefined
+  promptDisabled: boolean
+  onPromptChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void
+  onSuggestionClick: (suggestion: string) => void
+  onPromptSubmit: (message: PromptInputMessage) => Promise<void>
+  onCopyMessage: (messageId: string, text: string) => Promise<void>
+  onRetryMessage: (messageIndex: number) => void
+  onRestoreCheckpoint: (checkpoint: CheckpointMarker) => Promise<void>
+}
+
+export const useChatController = (): ChatController => {
+  const { meta } = useWorkbench()
+  const { selectedWorkspace, selectedChat } = meta
+
+  const [messages, setMessages] = React.useState<ChatMessage[]>([])
+  const [copiedMessageId, setCopiedMessageId] = React.useState<string | null>(null)
+  const [chatStatus, setChatStatus] = React.useState<"idle" | "streaming" | "error">(
+    "idle"
+  )
+  const [chatError, setChatError] = React.useState<string | null>(null)
+  const [restoreCheckpointError, setRestoreCheckpointError] = React.useState<
+    string | null
+  >(null)
+  const [restoringCheckpoints, setRestoringCheckpoints] = React.useState<
+    Record<string, boolean>
+  >({})
+  const [promptValue, setPromptValue] = React.useState("")
+  const [isTranscriptLoading, setIsTranscriptLoading] = React.useState(false)
+  const [isAwaitingFirstToken, setIsAwaitingFirstToken] = React.useState(false)
+  const streamAbortRef = React.useRef<AbortController | null>(null)
+  const transcriptAbortRef = React.useRef<AbortController | null>(null)
+  const copyTimeoutRef = React.useRef<number | null>(null)
+
+  const createLocalMessageId = React.useCallback(() => {
+    return `m_${Math.random().toString(36).slice(2, 10)}`
+  }, [])
+  const createLocalFileId = React.useCallback(() => {
+    return `f_${Math.random().toString(36).slice(2, 10)}`
+  }, [])
+
+  React.useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current !== null) {
+        window.clearTimeout(copyTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  const fetchTranscript = React.useCallback(
+    async (conversationId: string, sessionId: string, signal: AbortSignal) => {
+      const response = await fetch(
+        `/api/conversations/${conversationId}/sessions/${sessionId}/transcript`,
+        { signal }
+      )
+      if (!response.ok) {
+        throw new Error("Failed to load transcript.")
+      }
+      const transcript = (await response.json()) as {
+        role: "user" | "assistant"
+        content?: string
+        parts?: StructuredMessagePart[]
+        metadata?: Record<string, unknown>
+      }[]
+      setMessages(
+        transcript.map((entry) =>
+          createClientMessage({
+            id: createLocalMessageId(),
+            role: entry.role,
+            content: entry.content,
+            parts: entry.parts,
+            metadata: entry.metadata,
+          })
+        )
+      )
+    },
+    [createLocalMessageId]
+  )
+
+  const loadTranscript = React.useCallback(
+    async (resetPrompt: boolean) => {
+      streamAbortRef.current?.abort()
+      transcriptAbortRef.current?.abort()
+      if (resetPrompt) {
+        setMessages([])
+        setPromptValue("")
+        setChatStatus("idle")
+        setChatError(null)
+        setRestoreCheckpointError(null)
+        setIsAwaitingFirstToken(false)
+      }
+      const conversationId = selectedWorkspace?.id
+      const sessionId = selectedChat?.id
+      if (!conversationId || !sessionId) {
+        setIsTranscriptLoading(false)
+        return
+      }
+      const controller = new AbortController()
+      transcriptAbortRef.current = controller
+      setIsTranscriptLoading(true)
+      try {
+        await fetchTranscript(conversationId, sessionId, controller.signal)
+      } catch (err) {
+        if (controller.signal.aborted) {
+          return
+        }
+        setChatError(err instanceof Error ? err.message : "Failed to load transcript.")
+        setMessages([])
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsTranscriptLoading(false)
+        }
+      }
+    },
+    [fetchTranscript, selectedWorkspace?.id, selectedChat?.id]
+  )
+
+  React.useEffect(() => {
+    void loadTranscript(true)
+  }, [selectedWorkspace?.id, selectedChat?.id, loadTranscript])
+
+  const onPromptChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setPromptValue(event.target.value)
+  }
+
+  const onSuggestionClick = React.useCallback((suggestion: string) => {
+    setPromptValue(suggestion)
+    if (typeof document === "undefined") {
+      return
+    }
+    window.requestAnimationFrame(() => {
+      const textarea = document.querySelector(
+        'textarea[name="message"]'
+      ) as HTMLTextAreaElement | null
+      if (!textarea) {
+        return
+      }
+      textarea.focus()
+      textarea.setSelectionRange(suggestion.length, suggestion.length)
+    })
+  }, [])
+
+  const onPromptSubmit = async (message: PromptInputMessage) => {
+    if (!selectedWorkspace || !selectedChat) {
+      return
+    }
+    if (chatStatus === "streaming") {
+      return
+    }
+    const content = message.text.trim()
+    if (!content) {
+      return
+    }
+
+    const conversationId = selectedWorkspace.id
+    const sessionId = selectedChat.id
+    const userMessageId = createLocalMessageId()
+    const assistantMessageId = createLocalMessageId()
+    const attachmentParts: StructuredMessagePart[] = message.files.map((file) => {
+      const attachmentId = createLocalFileId()
+      return {
+        type: "file",
+        id: attachmentId,
+        file: {
+          id: attachmentId,
+          name: file.filename,
+          path: file.url,
+          mimeType: file.mediaType,
+          size: file.size,
+          source: "upload",
+        },
+      }
+    })
+    const userParts = normalizeMessageParts(content, [
+      { type: "text", text: content },
+      ...attachmentParts,
+    ])
+
+    setPromptValue("")
+    setChatError(null)
+    setIsAwaitingFirstToken(true)
+    setChatStatus("streaming")
+    setMessages((prev) => [
+      ...prev,
+      createClientMessage({ id: userMessageId, role: "user", content, parts: userParts }),
+      createClientMessage({
+        id: assistantMessageId,
+        role: "assistant",
+        content: "",
+        parts: [],
+        isStreaming: true,
+      }),
+    ])
+
+    const controller = new AbortController()
+    streamAbortRef.current = controller
+
+    try {
+      const response = await fetch(
+        `/api/conversations/${conversationId}/sessions/${sessionId}/chat/stream`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content, parts: userParts }),
+          signal: controller.signal,
+        }
+      )
+      if (!response.ok || !response.body) {
+        throw new Error("Failed to start streaming response.")
+      }
+
+      const reader = response.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ""
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) {
+          break
+        }
+        buffer += decoder.decode(value, { stream: true })
+        const parts = buffer.split("\n\n")
+        buffer = parts.pop() ?? ""
+
+        for (const part of parts) {
+          const lines = part.split("\n").filter(Boolean)
+          if (!lines.length) {
+            continue
+          }
+          let eventName = "message"
+          const dataLines: string[] = []
+          for (const line of lines) {
+            if (line.startsWith("event:")) {
+              eventName = line.replace(/^event:\s*/, "")
+            } else if (line.startsWith("data:")) {
+              dataLines.push(line.replace(/^data:\s*/, ""))
+            }
+          }
+          const rawData = dataLines.join("\n")
+          let data: any = rawData
+          if (rawData) {
+            try {
+              data = JSON.parse(rawData)
+            } catch {
+              data = rawData
+            }
+          }
+
+          if (eventName === "message_delta" && typeof data?.delta === "string") {
+            setIsAwaitingFirstToken(false)
+            setMessages((prev) =>
+              prev.map((message) =>
+                message.id === assistantMessageId
+                  ? applyMessageDelta(message, data.delta)
+                  : message
+              )
+            )
+            continue
+          }
+
+          if (eventName === "message_part_updated" || eventName === "message.part.updated") {
+            const incomingPart = data?.part
+            if (incomingPart && typeof incomingPart.type === "string") {
+              setIsAwaitingFirstToken(false)
+              setMessages((prev) =>
+                prev.map((message) => {
+                  if (message.id !== assistantMessageId) {
+                    return message
+                  }
+                  return applyMessagePartUpdate(
+                    message,
+                    incomingPart as StructuredMessagePart,
+                    data?.delta
+                  )
+                })
+              )
+            }
+            continue
+          }
+
+          if (eventName === "message_end") {
+            setIsAwaitingFirstToken(false)
+            setChatStatus("idle")
+            setMessages((prev) =>
+              prev.map((message) =>
+                message.id === assistantMessageId
+                  ? applyMessageEnd(message, {
+                      content: typeof data?.content === "string" ? data.content : undefined,
+                      parts: Array.isArray(data?.parts) ? data.parts : undefined,
+                    })
+                  : message
+              )
+            )
+            continue
+          }
+
+          if (eventName === "error") {
+            setIsAwaitingFirstToken(false)
+            setChatStatus("error")
+            setChatError(
+              typeof data?.message === "string" ? data.message : "Streaming failed."
+            )
+            setMessages((prev) =>
+              prev.map((message) =>
+                message.id === assistantMessageId
+                  ? { ...message, isStreaming: false }
+                  : message
+              )
+            )
+          }
+        }
+      }
+    } catch (err) {
+      if (controller.signal.aborted) {
+        return
+      }
+      setIsAwaitingFirstToken(false)
+      setChatStatus("error")
+      setChatError(err instanceof Error ? err.message : "Streaming failed.")
+      setMessages((prev) =>
+        prev.map((message) =>
+          message.id === assistantMessageId
+            ? { ...message, isStreaming: false }
+            : message
+        )
+      )
+    } finally {
+      if (!controller.signal.aborted) {
+        setIsAwaitingFirstToken(false)
+        setChatStatus((status) => (status === "streaming" ? "idle" : status))
+        setMessages((prev) =>
+          prev.map((message) =>
+            message.id === assistantMessageId
+              ? { ...message, isStreaming: false }
+              : message
+          )
+        )
+      }
+      streamAbortRef.current = null
+    }
+  }
+
+  const onCopyMessage = React.useCallback(
+    async (messageId: string, text: string) => {
+      const trimmed = text.trim()
+      if (!trimmed) {
+        return
+      }
+
+      try {
+        if (navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(trimmed)
+        } else {
+          const textarea = document.createElement("textarea")
+          textarea.value = trimmed
+          textarea.style.position = "fixed"
+          textarea.style.opacity = "0"
+          document.body.appendChild(textarea)
+          textarea.select()
+          document.execCommand("copy")
+          document.body.removeChild(textarea)
+        }
+      } catch {
+        return
+      }
+
+      setCopiedMessageId(messageId)
+      if (copyTimeoutRef.current !== null) {
+        window.clearTimeout(copyTimeoutRef.current)
+      }
+      copyTimeoutRef.current = window.setTimeout(() => {
+        setCopiedMessageId((current) => (current === messageId ? null : current))
+      }, 2000)
+    },
+    []
+  )
+
+  const onRetryMessage = React.useCallback(
+    (messageIndex: number) => {
+      if (chatStatus === "streaming") {
+        return
+      }
+
+      for (let index = messageIndex; index >= 0; index -= 1) {
+        const candidate = messages[index]
+        if (candidate?.role !== "user") {
+          continue
+        }
+        const candidateText = getTextFromParts(candidate.parts) || candidate.content || ""
+        if (candidateText.trim()) {
+          void onPromptSubmit({ text: candidateText, files: [] })
+          return
+        }
+      }
+    },
+    [chatStatus, messages, onPromptSubmit]
+  )
+
+  const onRestoreCheckpoint = React.useCallback(
+    async (checkpoint: CheckpointMarker) => {
+      if (!selectedWorkspace || !selectedChat) {
+        return
+      }
+      if (!checkpoint.restore) {
+        return
+      }
+      if (restoringCheckpoints[checkpoint.id]) {
+        return
+      }
+      setRestoreCheckpointError(null)
+      setRestoringCheckpoints((prev) => ({ ...prev, [checkpoint.id]: true }))
+      try {
+        let response: Response
+        if (checkpoint.restore.url) {
+          const method = (checkpoint.restore.method ?? "POST").toUpperCase()
+          const hasBody = checkpoint.restore.payload !== undefined && method !== "GET"
+          response = await fetch(checkpoint.restore.url, {
+            method,
+            headers: hasBody ? { "Content-Type": "application/json" } : undefined,
+            body: hasBody ? JSON.stringify(checkpoint.restore.payload) : undefined,
+          })
+        } else {
+          if (!checkpoint.restore.messageId) {
+            throw new Error("Checkpoint restore is missing a message id.")
+          }
+          response = await fetch(
+            `/api/conversations/${selectedWorkspace.id}/sessions/${selectedChat.id}/checkpoints/restore`,
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                messageId: checkpoint.restore.messageId,
+                partId: checkpoint.restore.partId,
+              }),
+            }
+          )
+        }
+        if (!response.ok) {
+          let message = "Failed to restore checkpoint."
+          try {
+            const payload = (await response.json()) as { error?: string }
+            if (payload.error) {
+              message = payload.error
+            }
+          } catch {
+            // Ignore parsing errors
+          }
+          throw new Error(message)
+        }
+        await loadTranscript(false)
+      } catch (err) {
+        setRestoreCheckpointError(
+          err instanceof Error ? err.message : "Failed to restore checkpoint."
+        )
+      } finally {
+        setRestoringCheckpoints((prev) => {
+          const next = { ...prev }
+          delete next[checkpoint.id]
+          return next
+        })
+      }
+    },
+    [
+      loadTranscript,
+      restoringCheckpoints,
+      selectedChat,
+      selectedWorkspace,
+      setRestoreCheckpointError,
+    ]
+  )
+
+  const usageFromMessages = React.useMemo(() => {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const usage = extractUsageFromMetadata(messages[index]?.metadata)
+      if (usage) {
+        return usage
+      }
+    }
+    return null
+  }, [messages])
+
+  const isChatStreaming = chatStatus === "streaming"
+  const contextUsage = usageFromMessages ?? undefined
+  const promptDisabled =
+    isChatStreaming || !selectedWorkspace || !selectedChat || isTranscriptLoading
+
+  return {
+    messages,
+    copiedMessageId,
+    chatStatus,
+    chatError,
+    restoreCheckpointError,
+    restoringCheckpoints,
+    promptValue,
+    isTranscriptLoading,
+    isAwaitingFirstToken,
+    isChatStreaming,
+    contextUsage,
+    promptDisabled,
+    onPromptChange,
+    onSuggestionClick,
+    onPromptSubmit,
+    onCopyMessage,
+    onRetryMessage,
+    onRestoreCheckpoint,
+  }
+}

--- a/apps/web/src/features/workbench/hooks/use-chat-model-options.tsx
+++ b/apps/web/src/features/workbench/hooks/use-chat-model-options.tsx
@@ -1,0 +1,56 @@
+import * as React from "react"
+
+import {
+  buildModelOptions,
+  collectSettingsModels,
+  getActiveProvider,
+} from "../selectors"
+import type { SettingsController } from "./use-settings-controller"
+
+type ChatModelOptionsInput = {
+  settings: Pick<
+    SettingsController,
+    "defaultModel" | "availableModels" | "settingsForm"
+  >
+  selectedChat: { model?: string } | null
+}
+
+type ChatModelOptionsResult = {
+  selectedModel: string
+  modelOptions: ReturnType<typeof buildModelOptions>
+}
+
+export const useChatModelOptions = ({
+  settings,
+  selectedChat,
+}: ChatModelOptionsInput): ChatModelOptionsResult => {
+  const fallbackModel = settings.defaultModel?.trim() || "openai/gpt-5.3-codex"
+  const selectedModel = selectedChat?.model ?? fallbackModel
+  const activeProvider = React.useMemo(() => getActiveProvider(selectedModel), [selectedModel])
+  const settingsModels = React.useMemo(
+    () => collectSettingsModels(settings.settingsForm.modelProviders),
+    [settings.settingsForm.modelProviders]
+  )
+  const modelOptions = React.useMemo(
+    () =>
+      buildModelOptions({
+        fallbackModel,
+        availableModels: settings.availableModels,
+        settingsModels,
+        selectedChatModel: selectedChat?.model,
+        activeProvider,
+      }),
+    [
+      activeProvider,
+      fallbackModel,
+      selectedChat?.model,
+      settings.availableModels,
+      settingsModels,
+    ]
+  )
+
+  return {
+    selectedModel,
+    modelOptions,
+  }
+}

--- a/apps/web/src/features/workbench/hooks/use-projects-controller.tsx
+++ b/apps/web/src/features/workbench/hooks/use-projects-controller.tsx
@@ -1,0 +1,576 @@
+import * as React from "react"
+
+import { useWorkbench } from "../workbench-context"
+import type {
+  ApiProject,
+  ApiSession,
+  ChatSession,
+  CreateConversationResponse,
+  ProjectFormState,
+  SessionFormState,
+  SettingsFormState,
+  WorkspaceFormState,
+} from "../types"
+
+type SettingsContext = {
+  settingsForm: SettingsFormState
+  addAvailableModel: (model: string) => void
+}
+
+type ProjectsControllerState = {
+  projectForm: ProjectFormState
+  isCreatingProject: boolean
+  isSelectingDirectory: boolean
+  createProjectError: string | null
+  workspaceForm: WorkspaceFormState
+  isCreatingWorkspace: boolean
+  createWorkspaceError: string | null
+  sessionForm: SessionFormState
+  isCreatingSession: boolean
+  createSessionError: string | null
+  deletingSessionId: string | null
+  deleteSessionError: string | null
+  deletingWorkspace: Record<string, boolean>
+  deleteWorkspaceErrors: Record<string, string>
+  isUpdatingModel: boolean
+  updateModelError: string | null
+}
+
+type ProjectsControllerActions = {
+  onProjectFormChange: (
+    field: keyof ProjectFormState
+  ) => (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => void
+  onWorkspaceFormChange: (event: React.ChangeEvent<HTMLInputElement>) => void
+  onSelectDirectory: () => Promise<void>
+  onCreateProject: (event: React.FormEvent<HTMLFormElement>) => Promise<void>
+  onCreateWorkspace: (event: React.FormEvent<HTMLFormElement>) => Promise<void>
+  onDeleteWorkspace: (workspaceId: string, workspaceName?: string) => Promise<boolean>
+  onConfirmDeleteWorkspace: (
+    workspaceId: string,
+    workspaceName?: string
+  ) => Promise<boolean>
+  onCreateSession: (event: React.FormEvent<HTMLFormElement>) => Promise<void>
+  onDeleteSession: (sessionId: string) => Promise<void>
+  onUpdateSessionModel: (modelId: string) => Promise<void>
+}
+
+type ProjectsController = {
+  state: ProjectsControllerState
+  actions: ProjectsControllerActions
+}
+
+export const useProjectsController = (settings: SettingsContext): ProjectsController => {
+  const { state: workbenchState, actions, meta } = useWorkbench()
+  const { selectedWorkspaceId, selectedChatId } = workbenchState
+  const { selectedProject, selectedWorkspace, selectedChat } = meta
+
+  const [projectForm, setProjectForm] = React.useState<ProjectFormState>({
+    name: "",
+    repoPath: "",
+    defaultBranch: "main",
+    gitProvider: "",
+    repoUrl: "",
+  })
+  const [isCreatingProject, setIsCreatingProject] = React.useState(false)
+  const [isSelectingDirectory, setIsSelectingDirectory] = React.useState(false)
+  const [createProjectError, setCreateProjectError] = React.useState<string | null>(null)
+  const [workspaceForm, setWorkspaceForm] = React.useState<WorkspaceFormState>({
+    title: "",
+  })
+  const [isCreatingWorkspace, setIsCreatingWorkspace] = React.useState(false)
+  const [createWorkspaceError, setCreateWorkspaceError] = React.useState<string | null>(
+    null
+  )
+  const [sessionForm, setSessionForm] = React.useState<SessionFormState>({
+    providerId: "",
+    modelId: "",
+  })
+  const [isCreatingSession, setIsCreatingSession] = React.useState(false)
+  const [createSessionError, setCreateSessionError] = React.useState<string | null>(null)
+  const [deletingSessionId, setDeletingSessionId] = React.useState<string | null>(null)
+  const [deleteSessionError, setDeleteSessionError] = React.useState<string | null>(null)
+  const [deletingWorkspace, setDeletingWorkspace] = React.useState<Record<string, boolean>>(
+    {}
+  )
+  const [deleteWorkspaceErrors, setDeleteWorkspaceErrors] = React.useState<
+    Record<string, string>
+  >({})
+  const [isUpdatingModel, setIsUpdatingModel] = React.useState(false)
+  const [updateModelError, setUpdateModelError] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    if (settings.settingsForm.modelProviders.length === 0) {
+      return
+    }
+    setSessionForm((prev) => {
+      const providerIds = settings.settingsForm.modelProviders.map(
+        (provider) => provider.id
+      )
+      const resolvedProviderId = providerIds.includes(prev.providerId)
+        ? prev.providerId
+        : providerIds.includes(settings.settingsForm.defaultProvider)
+          ? settings.settingsForm.defaultProvider
+          : settings.settingsForm.modelProviders[0]?.id || ""
+      const provider = settings.settingsForm.modelProviders.find(
+        (item) => item.id === resolvedProviderId
+      )
+      const modelIds = provider?.models.map((model) => model.id) ?? []
+      const resolvedModelId = modelIds.includes(prev.modelId)
+        ? prev.modelId
+        : modelIds.includes(settings.settingsForm.defaultModel)
+          ? settings.settingsForm.defaultModel
+          : provider?.models[0]?.id || ""
+      if (resolvedProviderId === prev.providerId && resolvedModelId === prev.modelId) {
+        return prev
+      }
+      return {
+        ...prev,
+        providerId: resolvedProviderId,
+        modelId: resolvedModelId,
+      }
+    })
+  }, [
+    settings.settingsForm.modelProviders,
+    settings.settingsForm.defaultProvider,
+    settings.settingsForm.defaultModel,
+  ])
+
+  React.useEffect(() => {
+    if (!selectedWorkspaceId) {
+      return
+    }
+    setDeleteWorkspaceErrors((prev) => {
+      const next = { ...prev }
+      delete next[selectedWorkspaceId]
+      return next
+    })
+  }, [selectedWorkspaceId])
+
+  React.useEffect(() => {
+    setDeleteSessionError(null)
+  }, [selectedWorkspaceId])
+
+  React.useEffect(() => {
+    setUpdateModelError(null)
+  }, [selectedChatId])
+
+  const onProjectFormChange = (field: keyof ProjectFormState) => {
+    return (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+      const value = event.target.value
+      setProjectForm((prev) => ({ ...prev, [field]: value }))
+    }
+  }
+
+  const onWorkspaceFormChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value
+    setWorkspaceForm({ title: value })
+  }
+
+  const onSelectDirectory = async () => {
+    setIsSelectingDirectory(true)
+    setCreateProjectError(null)
+    try {
+      const response = await fetch("/api/fs/select-directory", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ startPath: projectForm.repoPath || undefined }),
+      })
+      if (!response.ok) {
+        let message = "Failed to select folder."
+        try {
+          const payload = (await response.json()) as { error?: string }
+          if (payload.error) {
+            message = payload.error
+          }
+        } catch {
+          // Ignore parsing errors
+        }
+        throw new Error(message)
+      }
+      const payload = (await response.json()) as { path?: string }
+      if (payload.path) {
+        setProjectForm((prev) => ({ ...prev, repoPath: payload.path ?? "" }))
+      }
+    } catch (err) {
+      setCreateProjectError(
+        err instanceof Error ? err.message : "Failed to select folder."
+      )
+    } finally {
+      setIsSelectingDirectory(false)
+    }
+  }
+
+  const onCreateProject = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const name = projectForm.name.trim()
+    if (!name) {
+      setCreateProjectError("Project name is required.")
+      return
+    }
+    const defaultBranch = projectForm.defaultBranch.trim() || "main"
+    const repoPath = projectForm.repoPath.trim()
+
+    setIsCreatingProject(true)
+    setCreateProjectError(null)
+    try {
+      const response = await fetch("/api/projects", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name,
+          defaultBranch,
+          repoPath: repoPath || undefined,
+          gitProvider: projectForm.gitProvider || undefined,
+          repoUrl: projectForm.repoUrl.trim() || undefined,
+        }),
+      })
+      if (!response.ok) {
+        let message = "Failed to create project."
+        try {
+          const payload = (await response.json()) as { error?: string }
+          if (payload.error) {
+            message = payload.error
+          }
+        } catch {
+          // Ignore parsing errors
+        }
+        throw new Error(message)
+      }
+      const createdProject = (await response.json()) as ApiProject
+      setProjectForm({
+        name: "",
+        repoPath: "",
+        defaultBranch,
+        gitProvider: "",
+        repoUrl: "",
+      })
+      actions.selectProject(createdProject.id)
+      await actions.reloadProjects()
+    } catch (err) {
+      setCreateProjectError(
+        err instanceof Error ? err.message : "Failed to create project."
+      )
+    } finally {
+      setIsCreatingProject(false)
+    }
+  }
+
+  const onCreateWorkspace = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!selectedProject) {
+      return
+    }
+    const title = workspaceForm.title.trim()
+    setIsCreatingWorkspace(true)
+    setCreateWorkspaceError(null)
+    try {
+      const response = await fetch("/api/conversations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          projectId: selectedProject.id,
+          title: title || undefined,
+        }),
+      })
+      if (!response.ok) {
+        let message = "Failed to create workspace."
+        try {
+          const payload = (await response.json()) as { error?: string }
+          if (payload.error) {
+            message = payload.error
+          }
+        } catch {
+          // Ignore parsing errors
+        }
+        throw new Error(message)
+      }
+      const payload = (await response.json()) as CreateConversationResponse
+      setWorkspaceForm({ title: "" })
+      actions.selectChat(payload.project.id, payload.conversation.id, payload.session.id)
+      await actions.reloadProjects()
+    } catch (err) {
+      setCreateWorkspaceError(
+        err instanceof Error ? err.message : "Failed to create workspace."
+      )
+    } finally {
+      setIsCreatingWorkspace(false)
+    }
+  }
+
+  const onDeleteWorkspace = async (workspaceId: string, workspaceName?: string) => {
+    setDeletingWorkspace((prev) => ({ ...prev, [workspaceId]: true }))
+    setDeleteWorkspaceErrors((prev) => {
+      const next = { ...prev }
+      delete next[workspaceId]
+      return next
+    })
+    try {
+      const response = await fetch(`/api/conversations/${workspaceId}?confirm=true`, {
+        method: "DELETE",
+      })
+      if (!response.ok) {
+        let message = "Failed to delete workspace."
+        try {
+          const payload = (await response.json()) as { error?: string }
+          if (payload.error) {
+            message = payload.error
+          }
+        } catch {
+          // Ignore parsing errors
+        }
+        throw new Error(message)
+      }
+      if (selectedWorkspace?.id === workspaceId) {
+        actions.setSelectedWorkspaceId(null)
+        actions.setSelectedChatId(null)
+      }
+      await actions.reloadProjects()
+      return true
+    } catch (err) {
+      setDeleteWorkspaceErrors((prev) => ({
+        ...prev,
+        [workspaceId]:
+          err instanceof Error ? err.message : "Failed to delete workspace.",
+      }))
+      return false
+    } finally {
+      setDeletingWorkspace((prev) => ({ ...prev, [workspaceId]: false }))
+    }
+  }
+
+  const onConfirmDeleteWorkspace = async (
+    workspaceId: string,
+    workspaceName?: string
+  ) => {
+    const workspaceLabel = workspaceName || workspaceId
+    const confirmed = window.confirm(
+      `Delete workspace "${workspaceLabel}"? This removes the worktree and all sessions.`
+    )
+    if (!confirmed) {
+      return false
+    }
+    return onDeleteWorkspace(workspaceId, workspaceName)
+  }
+
+  const onCreateSession = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!selectedProject || !selectedWorkspace) {
+      return
+    }
+    const title = ""
+    const providerId = sessionForm.providerId.trim()
+    const modelId = sessionForm.modelId.trim()
+    const model = providerId && modelId ? `${providerId}/${modelId}` : undefined
+    setIsCreatingSession(true)
+    setCreateSessionError(null)
+    try {
+      const response = await fetch(
+        `/api/conversations/${selectedWorkspace.id}/sessions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title: title || undefined, model }),
+        }
+      )
+      if (!response.ok) {
+        let message = "Failed to create session."
+        try {
+          const payload = (await response.json()) as { error?: string }
+          if (payload.error) {
+            message = payload.error
+          }
+        } catch {
+          // Ignore parsing errors
+        }
+        throw new Error(message)
+      }
+      const session = (await response.json()) as ApiSession
+      const nextChat: ChatSession = {
+        id: session.id,
+        name: session.title?.trim() || session.model || session.id,
+        model: session.model,
+        createdAt: session.createdAt,
+        updatedAt: session.updatedAt,
+      }
+      actions.selectChat(selectedProject.id, selectedWorkspace.id, session.id)
+      actions.updateProjects((current) =>
+        current.map((project) => {
+          if (project.id !== selectedProject.id) {
+            return project
+          }
+          return {
+            ...project,
+            workspaces: project.workspaces.map((workspace) => {
+              if (workspace.id !== selectedWorkspace.id) {
+                return workspace
+              }
+              const existing = workspace.chats.some((chatEntry) => chatEntry.id === session.id)
+              if (existing) {
+                return workspace
+              }
+              return {
+                ...workspace,
+                chats: [nextChat, ...workspace.chats],
+              }
+            }),
+          }
+        })
+      )
+      await actions.reloadProjects()
+    } catch (err) {
+      setCreateSessionError(
+        err instanceof Error ? err.message : "Failed to create session."
+      )
+    } finally {
+      setIsCreatingSession(false)
+    }
+  }
+
+  const onDeleteSession = async (sessionId: string) => {
+    if (!selectedProject || !selectedWorkspace) {
+      return
+    }
+    const sessionLabel =
+      selectedWorkspace.chats.find((chatEntry) => chatEntry.id === sessionId)?.name ||
+      sessionId
+    const confirmed = window.confirm(`Delete session "${sessionLabel}"?`)
+    if (!confirmed) {
+      return
+    }
+    setDeletingSessionId(sessionId)
+    setDeleteSessionError(null)
+    try {
+      const response = await fetch(
+        `/api/conversations/${selectedWorkspace.id}/sessions/${sessionId}?confirm=true`,
+        {
+          method: "DELETE",
+        }
+      )
+      if (!response.ok) {
+        let message = "Failed to delete session."
+        try {
+          const payload = (await response.json()) as { error?: string }
+          if (payload.error) {
+            message = payload.error
+          }
+        } catch {
+          // Ignore parsing errors
+        }
+        throw new Error(message)
+      }
+      if (selectedChatId === sessionId) {
+        actions.setSelectedChatId(null)
+      }
+      await actions.reloadProjects()
+    } catch (err) {
+      setDeleteSessionError(
+        err instanceof Error ? err.message : "Failed to delete session."
+      )
+    } finally {
+      setDeletingSessionId((current) => (current === sessionId ? null : current))
+    }
+  }
+
+  const onUpdateSessionModel = async (modelId: string) => {
+    if (!selectedWorkspace || !selectedChat) {
+      return
+    }
+    if (selectedChat.model === modelId) {
+      return
+    }
+    setIsUpdatingModel(true)
+    setUpdateModelError(null)
+    try {
+      const response = await fetch(
+        `/api/conversations/${selectedWorkspace.id}/sessions/${selectedChat.id}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ model: modelId }),
+        }
+      )
+      if (!response.ok) {
+        let message = "Failed to update session model."
+        try {
+          const payload = (await response.json()) as { error?: string }
+          if (payload.error) {
+            message = payload.error
+          }
+        } catch {
+          // Ignore parsing errors
+        }
+        throw new Error(message)
+      }
+      const updatedSession = (await response.json()) as ApiSession
+      actions.updateProjects((prev) =>
+        prev.map((project) => ({
+          ...project,
+          workspaces: project.workspaces.map((workspace) => {
+            if (workspace.id !== updatedSession.conversationId) {
+              return workspace
+            }
+            return {
+              ...workspace,
+              chats: workspace.chats.map((chatEntry) =>
+                chatEntry.id === updatedSession.id
+                  ? {
+                      ...chatEntry,
+                      name:
+                        updatedSession.title?.trim() ||
+                        updatedSession.model ||
+                        updatedSession.id,
+                      model: updatedSession.model,
+                      updatedAt: updatedSession.updatedAt,
+                    }
+                  : chatEntry
+              ),
+            }
+          }),
+        }))
+      )
+      const updatedModel = updatedSession.model?.trim()
+      if (updatedModel) {
+        settings.addAvailableModel(updatedModel)
+      }
+    } catch (err) {
+      setUpdateModelError(
+        err instanceof Error ? err.message : "Failed to update session model."
+      )
+    } finally {
+      setIsUpdatingModel(false)
+    }
+  }
+
+  return {
+    state: {
+      projectForm,
+      isCreatingProject,
+      isSelectingDirectory,
+      createProjectError,
+      workspaceForm,
+      isCreatingWorkspace,
+      createWorkspaceError,
+      sessionForm,
+      isCreatingSession,
+      createSessionError,
+      deletingSessionId,
+      deleteSessionError,
+      deletingWorkspace,
+      deleteWorkspaceErrors,
+      isUpdatingModel,
+      updateModelError,
+    },
+    actions: {
+      onProjectFormChange,
+      onWorkspaceFormChange,
+      onSelectDirectory,
+      onCreateProject,
+      onCreateWorkspace,
+      onDeleteWorkspace,
+      onConfirmDeleteWorkspace,
+      onCreateSession,
+      onDeleteSession,
+      onUpdateSessionModel,
+    },
+  }
+}

--- a/apps/web/src/features/workbench/hooks/use-pull-requests-controller.tsx
+++ b/apps/web/src/features/workbench/hooks/use-pull-requests-controller.tsx
@@ -1,0 +1,293 @@
+import * as React from "react"
+
+import { useWorkbench } from "../workbench-context"
+import type { ApiPullRequest, MergedPullRequestAction, OpenPullRequest } from "../types"
+
+type PullRequestsControllerState = {
+  openPullRequests: OpenPullRequest[]
+  isLoadingPullRequests: boolean
+  pullRequestsError: string | null
+  mergingPullRequests: Record<string, boolean>
+  mergePullRequestErrors: Record<string, string>
+  mergedPullRequests: Record<string, MergedPullRequestAction>
+  deletingMergeWorkspace: Record<string, boolean>
+  deleteMergeWorkspaceErrors: Record<string, string>
+}
+
+type PullRequestsControllerActions = {
+  getPullRequestKey: (item: OpenPullRequest) => string
+  onMergePullRequest: (item: OpenPullRequest) => Promise<void>
+  onDeleteMergedWorkspace: (
+    pullRequestKey: string,
+    workspaceId: string,
+    workspaceName?: string
+  ) => Promise<void>
+}
+
+type PullRequestsController = {
+  state: PullRequestsControllerState
+  actions: PullRequestsControllerActions
+}
+
+export const usePullRequestsController = (): PullRequestsController => {
+  const { state: workbenchState, actions } = useWorkbench()
+  const { projects } = workbenchState
+
+  const [openPullRequests, setOpenPullRequests] = React.useState<OpenPullRequest[]>([])
+  const [isLoadingPullRequests, setIsLoadingPullRequests] = React.useState(false)
+  const [pullRequestsError, setPullRequestsError] = React.useState<string | null>(null)
+  const [mergingPullRequests, setMergingPullRequests] = React.useState<
+    Record<string, boolean>
+  >({})
+  const [mergePullRequestErrors, setMergePullRequestErrors] = React.useState<
+    Record<string, string>
+  >({})
+  const [mergedPullRequests, setMergedPullRequests] = React.useState<
+    Record<string, MergedPullRequestAction>
+  >({})
+  const [deletingMergeWorkspace, setDeletingMergeWorkspace] = React.useState<
+    Record<string, boolean>
+  >({})
+  const [deleteMergeWorkspaceErrors, setDeleteMergeWorkspaceErrors] = React.useState<
+    Record<string, string>
+  >({})
+
+  React.useEffect(() => {
+    if (!projects.length) {
+      setOpenPullRequests([])
+      setPullRequestsError(null)
+      return
+    }
+    let isActive = true
+    const loadPullRequests = async () => {
+      const targets = projects.filter((project) => project.repoUrl?.trim())
+      if (!targets.length) {
+        if (isActive) {
+          setOpenPullRequests([])
+          setPullRequestsError(null)
+          setIsLoadingPullRequests(false)
+        }
+        return
+      }
+      setIsLoadingPullRequests(true)
+      setPullRequestsError(null)
+      const errors: string[] = []
+      const results = await Promise.all(
+        targets.map(async (project) => {
+          try {
+            const response = await fetch(
+              `/api/projects/${project.id}/pull-requests?limit=10`
+            )
+            if (!response.ok) {
+              let message = `Failed to load pull requests for ${project.name}.`
+              try {
+                const payload = (await response.json()) as { error?: string }
+                if (payload.error) {
+                  message = payload.error
+                }
+              } catch {
+                // Ignore parsing errors
+              }
+              errors.push(message)
+              return [] as OpenPullRequest[]
+            }
+            const payload = (await response.json()) as ApiPullRequest[]
+            return payload.map((item) => ({
+              ...item,
+              projectId: project.id,
+              projectName: project.name,
+            }))
+          } catch (err) {
+            errors.push(
+              err instanceof Error
+                ? err.message
+                : `Failed to load pull requests for ${project.name}.`
+            )
+            return [] as OpenPullRequest[]
+          }
+        })
+      )
+      if (!isActive) {
+        return
+      }
+      const flattened = results.flat()
+      setOpenPullRequests(flattened)
+      setPullRequestsError(flattened.length ? null : errors[0] ?? null)
+      setIsLoadingPullRequests(false)
+    }
+    void loadPullRequests()
+    return () => {
+      isActive = false
+    }
+  }, [projects])
+
+  const getPullRequestKey = React.useCallback((item: OpenPullRequest) => {
+    return `${item.projectId}:${item.number}`
+  }, [])
+
+  const findWorkspaceForPullRequest = React.useCallback(
+    (item: OpenPullRequest) => {
+      const sourceBranch = item.sourceBranch?.trim().toLowerCase()
+      if (!sourceBranch) {
+        return undefined
+      }
+      const project = projects.find((entry) => entry.id === item.projectId)
+      if (!project) {
+        return undefined
+      }
+      return project.workspaces.find((workspace) => {
+        const branch = workspace.branch?.trim().toLowerCase()
+        return branch && branch === sourceBranch
+      })
+    },
+    [projects]
+  )
+
+  const onMergePullRequest = async (item: OpenPullRequest) => {
+    const key = getPullRequestKey(item)
+    if (mergingPullRequests[key]) {
+      return
+    }
+    const workspace = findWorkspaceForPullRequest(item)
+    setMergingPullRequests((prev) => ({ ...prev, [key]: true }))
+    setMergePullRequestErrors((prev) => {
+      const next = { ...prev }
+      delete next[key]
+      return next
+    })
+    try {
+      if (workspace) {
+        const statusResponse = await fetch(`/api/conversations/${workspace.id}/status`)
+        if (!statusResponse.ok) {
+          if (statusResponse.status !== 404) {
+            let message = "Failed to check workspace status."
+            try {
+              const payload = (await statusResponse.json()) as { error?: string }
+              if (payload.error) {
+                message = payload.error
+              }
+            } catch {
+              // Ignore parsing errors
+            }
+            throw new Error(message)
+          }
+        } else {
+          const payload = (await statusResponse.json()) as { dirty?: boolean }
+          if (payload.dirty) {
+            const confirmed = window.confirm(
+              `Workspace "${workspace.name}" has uncommitted changes. Merge anyway?`
+            )
+            if (!confirmed) {
+              return
+            }
+          }
+        }
+      }
+      const response = await fetch(
+        `/api/projects/${item.projectId}/pull-requests/${item.number}/merge`,
+        { method: "POST" }
+      )
+      if (!response.ok) {
+        let message = "Failed to merge pull request."
+        try {
+          const payload = (await response.json()) as { error?: string }
+          if (payload.error) {
+            message = payload.error
+          }
+        } catch {
+          // Ignore parsing errors
+        }
+        if (response.status === 404 && message === "Not Found") {
+          message =
+            "Merge endpoint not found. Restart the CLI server to pick up the merge API."
+        }
+        throw new Error(message)
+      }
+      setMergedPullRequests((prev) => ({
+        ...prev,
+        [key]: {
+          workspaceId: workspace?.id,
+          workspaceName: workspace?.name,
+        },
+      }))
+    } catch (err) {
+      setMergePullRequestErrors((prev) => ({
+        ...prev,
+        [key]: err instanceof Error ? err.message : "Failed to merge pull request.",
+      }))
+    } finally {
+      setMergingPullRequests((prev) => ({ ...prev, [key]: false }))
+    }
+  }
+
+  const onDeleteMergedWorkspace = async (
+    pullRequestKey: string,
+    workspaceId: string,
+    workspaceName?: string
+  ) => {
+    const label = workspaceName || workspaceId
+    const confirmed = window.confirm(
+      `Delete workspace "${label}"? This removes the worktree and all sessions.`
+    )
+    if (!confirmed) {
+      return
+    }
+    setDeletingMergeWorkspace((prev) => ({ ...prev, [workspaceId]: true }))
+    setDeleteMergeWorkspaceErrors((prev) => {
+      const next = { ...prev }
+      delete next[workspaceId]
+      return next
+    })
+    try {
+      const response = await fetch(`/api/conversations/${workspaceId}?confirm=true`, {
+        method: "DELETE",
+      })
+      if (!response.ok) {
+        let message = "Failed to delete workspace."
+        try {
+          const payload = (await response.json()) as { error?: string }
+          if (payload.error) {
+            message = payload.error
+          }
+        } catch {
+          // Ignore parsing errors
+        }
+        throw new Error(message)
+      }
+      await actions.reloadProjects()
+      setMergedPullRequests((prev) => ({
+        ...prev,
+        [pullRequestKey]: {
+          ...prev[pullRequestKey],
+          workspaceDeleted: true,
+        },
+      }))
+    } catch (err) {
+      setDeleteMergeWorkspaceErrors((prev) => ({
+        ...prev,
+        [workspaceId]:
+          err instanceof Error ? err.message : "Failed to delete workspace.",
+      }))
+    } finally {
+      setDeletingMergeWorkspace((prev) => ({ ...prev, [workspaceId]: false }))
+    }
+  }
+
+  return {
+    state: {
+      openPullRequests,
+      isLoadingPullRequests,
+      pullRequestsError,
+      mergingPullRequests,
+      mergePullRequestErrors,
+      mergedPullRequests,
+      deletingMergeWorkspace,
+      deleteMergeWorkspaceErrors,
+    },
+    actions: {
+      getPullRequestKey,
+      onMergePullRequest,
+      onDeleteMergedWorkspace,
+    },
+  }
+}

--- a/apps/web/src/features/workbench/hooks/use-settings-controller.tsx
+++ b/apps/web/src/features/workbench/hooks/use-settings-controller.tsx
@@ -1,0 +1,274 @@
+import * as React from "react"
+
+import type { ApiModelsResponse, ModelProvider, SettingsFormState } from "../types"
+
+export type SettingsController = {
+  settingsForm: SettingsFormState
+  settingsDefaultModels: ModelProvider["models"]
+  settingsError: string | null
+  settingsSavedMessage: string | null
+  isSavingSettings: boolean
+  defaultModel: string | null
+  availableModels: string[]
+  addAvailableModel: (model: string) => void
+  onSettingsSubmit: (event: React.FormEvent<HTMLFormElement>) => Promise<void>
+  onSettingsChange: (field: "githubToken" | "gotlandToken") =>
+    (event: React.ChangeEvent<HTMLInputElement>) => void
+  updateModelProvider: (index: number, updater: (provider: ModelProvider) => ModelProvider) => void
+  onAddProvider: () => void
+  onRemoveProvider: (index: number) => void
+  onAddModel: (providerIndex: number) => void
+  onRemoveModel: (providerIndex: number, modelIndex: number) => void
+  onDefaultProviderChange: (event: React.ChangeEvent<HTMLSelectElement>) => void
+  onDefaultModelChange: (event: React.ChangeEvent<HTMLSelectElement>) => void
+}
+
+export const useSettingsController = (): SettingsController => {
+  const [settingsForm, setSettingsForm] = React.useState<SettingsFormState>({
+    githubToken: "",
+    gotlandToken: "",
+    modelProviders: [],
+    defaultProvider: "",
+    defaultModel: "",
+  })
+  const [settingsError, setSettingsError] = React.useState<string | null>(null)
+  const [settingsSavedMessage, setSettingsSavedMessage] = React.useState<string | null>(
+    null
+  )
+  const [isSavingSettings, setIsSavingSettings] = React.useState(false)
+  const [defaultModel, setDefaultModel] = React.useState<string | null>(null)
+  const [availableModels, setAvailableModels] = React.useState<string[]>([])
+
+  const loadSettings = React.useCallback(async () => {
+    setSettingsError(null)
+    try {
+      const response = await fetch("/api/settings")
+      if (!response.ok) {
+        throw new Error("Failed to load settings.")
+      }
+      const payload = (await response.json()) as {
+        githubToken?: string
+        gotlandToken?: string
+        modelProviders?: ModelProvider[]
+        defaultProvider?: string
+        defaultModel?: string
+      }
+      setSettingsForm({
+        githubToken: payload.githubToken ?? "",
+        gotlandToken: payload.gotlandToken ?? "",
+        modelProviders: payload.modelProviders ?? [],
+        defaultProvider: payload.defaultProvider ?? "",
+        defaultModel: payload.defaultModel ?? "",
+      })
+    } catch (err) {
+      setSettingsError(
+        err instanceof Error ? err.message : "Failed to load settings."
+      )
+    }
+  }, [])
+
+  const loadModels = React.useCallback(async () => {
+    try {
+      const response = await fetch("/api/models")
+      if (!response.ok) {
+        return
+      }
+      const payload = (await response.json()) as ApiModelsResponse
+      const modelValues = Array.isArray(payload.models)
+        ? payload.models.map((model) => model.trim()).filter(Boolean)
+        : []
+      setDefaultModel(payload.defaultModel?.trim() || null)
+      setAvailableModels(Array.from(new Set(modelValues)))
+    } catch {
+      // Ignore model load errors and fall back to defaults
+    }
+  }, [])
+
+  React.useEffect(() => {
+    void loadSettings()
+  }, [loadSettings])
+
+  React.useEffect(() => {
+    if (settingsForm.modelProviders.length === 0) {
+      return
+    }
+    setSettingsForm((prev) => {
+      const providerIds = prev.modelProviders.map((provider) => provider.id)
+      const resolvedProviderId = providerIds.includes(prev.defaultProvider)
+        ? prev.defaultProvider
+        : prev.modelProviders[0]?.id || ""
+      const provider = prev.modelProviders.find((item) => item.id === resolvedProviderId)
+      const modelIds = provider?.models.map((model) => model.id) ?? []
+      const resolvedModelId = modelIds.includes(prev.defaultModel)
+        ? prev.defaultModel
+        : provider?.models[0]?.id || ""
+      if (
+        resolvedProviderId === prev.defaultProvider &&
+        resolvedModelId === prev.defaultModel
+      ) {
+        return prev
+      }
+      return {
+        ...prev,
+        defaultProvider: resolvedProviderId,
+        defaultModel: resolvedModelId,
+      }
+    })
+  }, [settingsForm.modelProviders])
+
+  React.useEffect(() => {
+    void loadModels()
+  }, [loadModels])
+
+  const onSettingsChange = (field: "githubToken" | "gotlandToken") => {
+    return (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value
+      setSettingsForm((prev) => ({ ...prev, [field]: value }))
+      setSettingsSavedMessage(null)
+    }
+  }
+
+  const updateModelProvider = (
+    index: number,
+    updater: (provider: ModelProvider) => ModelProvider
+  ) => {
+    setSettingsForm((prev) => {
+      const nextProviders = prev.modelProviders.map((provider, providerIndex) =>
+        providerIndex === index ? updater(provider) : provider
+      )
+      return { ...prev, modelProviders: nextProviders }
+    })
+    setSettingsSavedMessage(null)
+  }
+
+  const onAddProvider = () => {
+    setSettingsForm((prev) => ({
+      ...prev,
+      modelProviders: [...prev.modelProviders, { id: "", name: "", models: [] }],
+    }))
+    setSettingsSavedMessage(null)
+  }
+
+  const onRemoveProvider = (index: number) => {
+    setSettingsForm((prev) => ({
+      ...prev,
+      modelProviders: prev.modelProviders.filter((_, providerIndex) => providerIndex !== index),
+    }))
+    setSettingsSavedMessage(null)
+  }
+
+  const onAddModel = (providerIndex: number) => {
+    updateModelProvider(providerIndex, (provider) => ({
+      ...provider,
+      models: [...provider.models, { id: "", name: "" }],
+    }))
+  }
+
+  const onRemoveModel = (providerIndex: number, modelIndex: number) => {
+    updateModelProvider(providerIndex, (provider) => ({
+      ...provider,
+      models: provider.models.filter((_, index) => index !== modelIndex),
+    }))
+  }
+
+  const onDefaultProviderChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value
+    setSettingsForm((prev) => {
+      const provider = prev.modelProviders.find((item) => item.id === value)
+      const modelId =
+        provider?.models.find((model) => model.id === prev.defaultModel)?.id ??
+        provider?.models[0]?.id ??
+        ""
+      return { ...prev, defaultProvider: value, defaultModel: modelId }
+    })
+    setSettingsSavedMessage(null)
+  }
+
+  const onDefaultModelChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value
+    setSettingsForm((prev) => ({ ...prev, defaultModel: value }))
+    setSettingsSavedMessage(null)
+  }
+
+  const onSettingsSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setIsSavingSettings(true)
+    setSettingsError(null)
+    setSettingsSavedMessage(null)
+    try {
+      const response = await fetch("/api/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          githubToken: settingsForm.githubToken.trim() || null,
+          gotlandToken: settingsForm.gotlandToken.trim() || null,
+          modelProviders: settingsForm.modelProviders,
+          defaultProvider: settingsForm.defaultProvider.trim() || null,
+          defaultModel: settingsForm.defaultModel.trim() || null,
+        }),
+      })
+      if (!response.ok) {
+        let message = "Failed to save settings."
+        try {
+          const payload = (await response.json()) as { error?: string }
+          if (payload.error) {
+            message = payload.error
+          }
+        } catch {
+          // Ignore parsing errors
+        }
+        throw new Error(message)
+      }
+      const payload = (await response.json()) as {
+        githubToken?: string
+        gotlandToken?: string
+        modelProviders?: ModelProvider[]
+        defaultProvider?: string
+        defaultModel?: string
+      }
+      setSettingsForm({
+        githubToken: payload.githubToken ?? "",
+        gotlandToken: payload.gotlandToken ?? "",
+        modelProviders: payload.modelProviders ?? [],
+        defaultProvider: payload.defaultProvider ?? "",
+        defaultModel: payload.defaultModel ?? "",
+      })
+      setSettingsSavedMessage("Settings saved.")
+    } catch (err) {
+      setSettingsError(
+        err instanceof Error ? err.message : "Failed to save settings."
+      )
+    } finally {
+      setIsSavingSettings(false)
+    }
+  }
+
+  const addAvailableModel = React.useCallback((model: string) => {
+    setAvailableModels((prev) => (prev.includes(model) ? prev : [...prev, model]))
+  }, [])
+
+  const settingsDefaultProvider = settingsForm.modelProviders.find(
+    (provider) => provider.id === settingsForm.defaultProvider
+  )
+  const settingsDefaultModels = settingsDefaultProvider?.models ?? []
+
+  return {
+    settingsForm,
+    settingsDefaultModels,
+    settingsError,
+    settingsSavedMessage,
+    isSavingSettings,
+    defaultModel,
+    availableModels,
+    addAvailableModel,
+    onSettingsSubmit,
+    onSettingsChange,
+    updateModelProvider,
+    onAddProvider,
+    onRemoveProvider,
+    onAddModel,
+    onRemoveModel,
+    onDefaultProviderChange,
+    onDefaultModelChange,
+  }
+}

--- a/apps/web/src/features/workbench/hooks/use-workbench-view-model.tsx
+++ b/apps/web/src/features/workbench/hooks/use-workbench-view-model.tsx
@@ -1,0 +1,152 @@
+import * as React from "react"
+
+import type { Project, RecentSession, Workspace } from "../types"
+
+type WorkbenchViewModelInput = {
+  projects: Project[]
+  isLoading: boolean
+  error: string | null
+  selectedProject: Project | null
+  selectedWorkspace: Workspace | null
+  selectedChat: { id: string; name: string } | null
+  isProjectsView: boolean
+  isSettingsView: boolean
+  isProjectView: boolean
+  isWorkspaceView: boolean
+  isChatView: boolean
+  recentSessions: RecentSession[]
+  projectRecentSessions: RecentSession[]
+}
+
+type WorkbenchMainView = "projects" | "project" | "workspace" | "chat" | "secondary"
+type WorkbenchContentVariant = "settings" | "main"
+
+type WorkbenchViewModel = {
+  viewLabel: string
+  viewTitle: string
+  viewDescription: string
+  secondaryTitle: string
+  secondaryItems: string[]
+  projectRepoLabel: string | undefined
+  projectRepoHref: string | null
+  recentSessionsForView: RecentSession[]
+  mainView: WorkbenchMainView
+  contentVariant: WorkbenchContentVariant
+}
+
+export const useWorkbenchViewModel = ({
+  projects,
+  isLoading,
+  error,
+  selectedProject,
+  selectedWorkspace,
+  selectedChat,
+  isProjectsView,
+  isSettingsView,
+  isProjectView,
+  isWorkspaceView,
+  isChatView,
+  recentSessions,
+  projectRecentSessions,
+}: WorkbenchViewModelInput): WorkbenchViewModel => {
+  return React.useMemo(() => {
+    const viewLabel = isSettingsView
+      ? "Settings"
+      : isChatView
+        ? "Chat Session"
+        : isWorkspaceView
+          ? "Workspace"
+          : isProjectView
+            ? "Project"
+            : "Home"
+
+    const viewTitle = isSettingsView
+      ? "Settings"
+      : isProjectsView
+        ? "Home"
+        : selectedChat?.name ??
+          selectedWorkspace?.name ??
+          selectedProject?.name ??
+          (isLoading ? "Syncing projects" : "Choose a project")
+
+    const viewDescription = isSettingsView
+      ? "Manage access tokens and appearance for Maestro."
+      : isProjectsView
+        ? "Home for your projects, new work, and recent workspaces."
+        : selectedChat
+          ? `Workspace in ${selectedWorkspace?.name ?? "workspace"}.`
+          : selectedWorkspace
+            ? "Workspace activity, members, and recent sessions."
+            : selectedProject
+              ? `Repo: ${selectedProject.repoUrl?.trim() || selectedProject.repoPath}`
+              : isLoading
+                ? "Fetching projects, workspaces, and sessions."
+                : error
+                  ? error
+                  : "Select a project to explore its workspaces."
+
+    const secondaryTitle = isChatView
+      ? "Workspace context"
+      : isWorkspaceView
+        ? "Chat sessions"
+        : isProjectView
+          ? "Workspaces"
+          : "Projects"
+
+    const secondaryItems = isLoading
+      ? ["Loading projects..."]
+      : error
+        ? ["Unable to load projects."]
+        : isChatView
+          ? [selectedProject?.name ?? "", selectedWorkspace?.name ?? ""].filter(Boolean)
+          : isWorkspaceView
+            ? selectedWorkspace?.chats.map((chatEntry) => chatEntry.name) ?? []
+            : isProjectView
+              ? selectedProject?.workspaces.map((workspace) => workspace.name) ?? []
+              : projects.map((project) => project.name)
+
+    const projectRepoLabel = selectedProject?.repoUrl?.trim() || selectedProject?.repoPath
+    const projectRepoHref =
+      selectedProject?.repoUrl?.trim() && selectedProject.repoUrl.trim().startsWith("http")
+        ? selectedProject.repoUrl.trim()
+        : null
+    const recentSessionsForView = isProjectView ? projectRecentSessions : recentSessions
+    const mainView = isProjectsView
+      ? "projects"
+      : isProjectView
+        ? "project"
+        : isWorkspaceView
+          ? "workspace"
+          : isChatView
+            ? "chat"
+            : "secondary"
+    const contentVariant = isSettingsView ? "settings" : "main"
+
+    return {
+      viewLabel,
+      viewTitle,
+      viewDescription,
+      secondaryTitle,
+      secondaryItems,
+      projectRepoLabel,
+      projectRepoHref,
+      recentSessionsForView,
+      mainView,
+      contentVariant,
+    }
+  }, [
+    projects,
+    isLoading,
+    error,
+    selectedProject,
+    selectedWorkspace,
+    selectedChat,
+    isProjectsView,
+    isSettingsView,
+    isProjectView,
+    isWorkspaceView,
+    isChatView,
+    recentSessions,
+    projectRecentSessions,
+  ])
+}

--- a/apps/web/src/features/workbench/views/workbench-overview.tsx
+++ b/apps/web/src/features/workbench/views/workbench-overview.tsx
@@ -1,5 +1,5 @@
-import { Badge } from "../../../components/ui/badge"
-import { Button } from "../../../components/ui/button"
+import { WorkbenchOverviewHeader } from "../components/workbench-overview-header"
+import { WorkbenchOverviewRecent } from "../components/workbench-overview-recent"
 import type { Project, RecentSession, Workspace } from "../types"
 
 type WorkbenchOverviewProps = {
@@ -43,105 +43,28 @@ export const WorkbenchOverview = ({
 }: WorkbenchOverviewProps) => {
   return (
     <>
-      <div className="rounded-xl border bg-card p-6 shadow-sm">
-        <div className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-          {viewLabel}
-        </div>
-        <div className="mt-3 flex flex-wrap items-center gap-3 text-2xl font-semibold text-foreground">
-          {isProjectView && projectIconValue ? (
-            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted text-lg">
-              {projectIconValue}
-            </div>
-          ) : null}
-          <span>{viewTitle}</span>
-        </div>
-        <div className="mt-2 max-w-2xl text-sm text-muted-foreground">
-          {viewDescription}
-        </div>
-        {isProjectView && selectedProject ? (
-          <div className="mt-3 flex flex-wrap items-center gap-2 text-sm">
-            <span className="text-muted-foreground">Repository</span>
-            {projectRepoHref ? (
-              <a
-                className="font-medium text-primary hover:underline"
-                href={projectRepoHref}
-                target="_blank"
-                rel="noreferrer"
-              >
-                Open repo
-              </a>
-            ) : (
-              <span className="text-foreground">{projectRepoLabel}</span>
-            )}
-            {selectedProject.gitProvider ? (
-              <Badge variant="secondary">
-                {selectedProject.gitProvider === "github" ? "GitHub" : "GitLab"}
-              </Badge>
-            ) : null}
-          </div>
-        ) : null}
-        {isWorkspaceView ? (
-          <div className="mt-4 flex flex-wrap items-center gap-3">
-            <Button
-              type="button"
-              variant="destructive"
-              onClick={() =>
-                selectedWorkspace
-                  ? onDeleteWorkspace(selectedWorkspace.id, selectedWorkspace.name)
-                  : undefined
-              }
-              disabled={
-                selectedWorkspace ? Boolean(deletingWorkspace[selectedWorkspace.id]) : false
-              }
-            >
-              {selectedWorkspace && deletingWorkspace[selectedWorkspace.id]
-                ? "Deleting workspace..."
-                : "Delete workspace"}
-            </Button>
-            {selectedWorkspace && deleteWorkspaceErrors[selectedWorkspace.id] ? (
-              <div className="rounded-md border border-destructive/50 bg-destructive/5 px-3 py-2 text-xs text-destructive">
-                {deleteWorkspaceErrors[selectedWorkspace.id]}
-              </div>
-            ) : null}
-          </div>
-        ) : null}
-      </div>
-      <div className="rounded-xl border bg-background p-4">
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <div>
-            <div className="text-sm font-semibold text-foreground">Recent sessions</div>
-            <div className="text-xs text-muted-foreground">
-              {isProjectView
-                ? `Last ${recentSessionsLimit} sessions in this project.`
-                : `Last ${recentSessionsLimit} sessions across your workspaces.`}
-            </div>
-          </div>
-        </div>
-        <div className="mt-4 flex gap-3 overflow-x-auto pb-2">
-          {recentSessionsForView.length ? (
-            recentSessionsForView.map((session) => (
-              <button
-                key={session.id}
-                type="button"
-                onClick={() => onSelectChat(session.projectId, session.workspaceId, session.id)}
-                className="min-w-[220px] rounded-lg border bg-muted/20 px-4 py-3 text-left transition hover:border-primary/60 hover:bg-muted/40"
-              >
-                <div className="text-sm font-semibold text-foreground">{session.name}</div>
-                <div className="mt-1 text-xs text-muted-foreground">
-                  {session.projectName} · {session.workspaceName}
-                </div>
-                <div className="mt-2 text-xs text-muted-foreground">
-                  Updated {formatDateTime(session.updatedAt)}
-                </div>
-              </button>
-            ))
-          ) : (
-            <div className="rounded-lg border border-dashed px-4 py-3 text-sm text-muted-foreground">
-              No sessions yet. Create a workspace to start chatting.
-            </div>
-          )}
-        </div>
-      </div>
+      <WorkbenchOverviewHeader
+        isProjectView={isProjectView}
+        isWorkspaceView={isWorkspaceView}
+        selectedProject={selectedProject}
+        selectedWorkspace={selectedWorkspace}
+        projectIconValue={projectIconValue}
+        viewLabel={viewLabel}
+        viewTitle={viewTitle}
+        viewDescription={viewDescription}
+        projectRepoLabel={projectRepoLabel}
+        projectRepoHref={projectRepoHref}
+        deletingWorkspace={deletingWorkspace}
+        deleteWorkspaceErrors={deleteWorkspaceErrors}
+        onDeleteWorkspace={onDeleteWorkspace}
+      />
+      <WorkbenchOverviewRecent
+        isProjectView={isProjectView}
+        recentSessionsLimit={recentSessionsLimit}
+        recentSessionsForView={recentSessionsForView}
+        formatDateTime={formatDateTime}
+        onSelectChat={onSelectChat}
+      />
     </>
   )
 }

--- a/apps/web/src/features/workbench/workbench-context.tsx
+++ b/apps/web/src/features/workbench/workbench-context.tsx
@@ -1,0 +1,347 @@
+import * as React from "react"
+
+import type {
+  ApiConversation,
+  ApiProject,
+  ApiSession,
+  Project,
+  Workspace,
+} from "./types"
+
+type WorkbenchView = "workbench" | "projects" | "settings"
+
+type WorkbenchState = {
+  projects: Project[]
+  isLoading: boolean
+  error: string | null
+  view: WorkbenchView
+  selectedProjectId: string | null
+  selectedWorkspaceId: string | null
+  selectedChatId: string | null
+}
+
+type WorkbenchActions = {
+  reloadProjects: () => Promise<void>
+  updateProjects: (updater: (current: Project[]) => Project[]) => void
+  selectProjectsView: () => void
+  selectSettingsView: () => void
+  selectProject: (projectId: string) => void
+  selectWorkspace: (projectId: string, workspaceId: string) => void
+  selectChat: (projectId: string, workspaceId: string, chatId: string) => void
+  setSelectedWorkspaceId: (workspaceId: string | null) => void
+  setSelectedChatId: (chatId: string | null) => void
+}
+
+type WorkbenchMeta = {
+  isProjectsView: boolean
+  isSettingsView: boolean
+  isProjectView: boolean
+  isWorkspaceView: boolean
+  isChatView: boolean
+  selectedProject: Project | null
+  selectedWorkspace: Workspace | null
+  selectedChat: { id: string; name: string; model?: string } | null
+}
+
+type WorkbenchContextValue = {
+  state: WorkbenchState
+  actions: WorkbenchActions
+  meta: WorkbenchMeta
+}
+
+const WorkbenchContext = React.createContext<WorkbenchContextValue | null>(null)
+
+export function WorkbenchProvider({ children }: { children: React.ReactNode }) {
+  const [projects, setProjects] = React.useState<Project[]>([])
+  const [isLoading, setIsLoading] = React.useState(true)
+  const [error, setError] = React.useState<string | null>(null)
+  const [view, setView] = React.useState<WorkbenchView>("workbench")
+  const [selectedProjectId, setSelectedProjectId] = React.useState<string | null>(
+    null
+  )
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = React.useState<string | null>(
+    null
+  )
+  const [selectedChatId, setSelectedChatId] = React.useState<string | null>(null)
+
+  const reloadProjects = React.useCallback(async () => {
+    setIsLoading(true)
+    setError(null)
+    try {
+      const [projectsRes, conversationsRes] = await Promise.all([
+        fetch("/api/projects?all=1"),
+        fetch("/api/conversations"),
+      ])
+      if (!projectsRes.ok) {
+        throw new Error("Failed to load projects.")
+      }
+      if (!conversationsRes.ok) {
+        throw new Error("Failed to load workspaces.")
+      }
+
+      const apiProjects = (await projectsRes.json()) as ApiProject[]
+      const conversations = (await conversationsRes.json()) as ApiConversation[]
+      const sessionsResults = await Promise.all(
+        conversations.map(async (conversation) => {
+          const response = await fetch(
+            `/api/conversations/${conversation.id}/sessions`
+          )
+          if (!response.ok) {
+            return { conversationId: conversation.id, sessions: [] as ApiSession[] }
+          }
+          const sessions = (await response.json()) as ApiSession[]
+          return { conversationId: conversation.id, sessions }
+        })
+      )
+
+      const sessionsByConversation = new Map(
+        sessionsResults.map((result) => [result.conversationId, result.sessions])
+      )
+
+      const nextProjects = apiProjects.map((project) => {
+        const projectConversations = conversations.filter(
+          (conversation) => conversation.projectId === project.id
+        )
+        const workspaces: Workspace[] = projectConversations.map((conversation) => {
+          const workspaceLabelFromPath = conversation.workspacePath
+            .split(/[\\/]/)
+            .filter(Boolean)
+            .pop()
+          const workspaceName =
+            conversation.title?.trim() ||
+            workspaceLabelFromPath ||
+            conversation.branch ||
+            conversation.id
+          const sessions = sessionsByConversation.get(conversation.id) ?? []
+          return {
+            id: conversation.id,
+            name: workspaceName,
+            branch: conversation.branch,
+            chats: sessions.map((session) => ({
+              id: session.id,
+              name: session.title?.trim() || session.model || session.id,
+              model: session.model,
+              createdAt: session.createdAt,
+              updatedAt: session.updatedAt,
+            })),
+            createdAt: conversation.createdAt,
+            updatedAt: conversation.updatedAt,
+          }
+        })
+
+        return {
+          id: project.id,
+          name: project.name,
+          icon: project.icon,
+          repoPath: project.repoPath,
+          defaultBranch: project.defaultBranch,
+          gitProvider: project.gitProvider,
+          repoUrl: project.repoUrl,
+          createdAt: project.createdAt,
+          updatedAt: project.updatedAt,
+          workspaces,
+        }
+      })
+
+      setProjects(nextProjects)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load projects.")
+      setProjects([])
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  const updateProjects = React.useCallback(
+    (updater: (current: Project[]) => Project[]) => {
+      setProjects((current) => updater(current))
+    },
+    []
+  )
+
+  const selectProjectsView = React.useCallback(() => {
+    setView("projects")
+    setSelectedProjectId(null)
+    setSelectedWorkspaceId(null)
+    setSelectedChatId(null)
+  }, [])
+
+  const selectSettingsView = React.useCallback(() => {
+    setView("settings")
+  }, [])
+
+  const selectProject = React.useCallback((projectId: string) => {
+    setView("workbench")
+    setSelectedProjectId(projectId)
+    setSelectedWorkspaceId(null)
+    setSelectedChatId(null)
+  }, [])
+
+  const selectWorkspace = React.useCallback(
+    (projectId: string, workspaceId: string) => {
+      setView("workbench")
+      setSelectedProjectId(projectId)
+      setSelectedWorkspaceId(workspaceId)
+      setSelectedChatId(null)
+    },
+    []
+  )
+
+  const selectChat = React.useCallback(
+    (projectId: string, workspaceId: string, chatId: string) => {
+      setView("workbench")
+      setSelectedProjectId(projectId)
+      setSelectedWorkspaceId(workspaceId)
+      setSelectedChatId(chatId)
+    },
+    []
+  )
+
+  React.useEffect(() => {
+    void reloadProjects()
+  }, [reloadProjects])
+
+  React.useEffect(() => {
+    if (!projects.length) {
+      setSelectedProjectId(null)
+      setSelectedWorkspaceId(null)
+      setSelectedChatId(null)
+      return
+    }
+    if (view === "projects") {
+      setSelectedProjectId(null)
+      setSelectedWorkspaceId(null)
+      setSelectedChatId(null)
+      return
+    }
+    const project =
+      projects.find((item) => item.id === selectedProjectId) ?? projects[0]
+    const shouldSelectWorkspace =
+      selectedWorkspaceId !== null ||
+      selectedChatId !== null ||
+      selectedProjectId === null
+    const workspace = shouldSelectWorkspace
+      ? project.workspaces.find((item) => item.id === selectedWorkspaceId) ??
+        project.workspaces[0] ??
+        null
+      : null
+    const chat = shouldSelectWorkspace
+      ? workspace?.chats.find((item) => item.id === selectedChatId) ??
+        workspace?.chats[0] ??
+        null
+      : null
+    setSelectedProjectId(project.id)
+    setSelectedWorkspaceId(workspace?.id ?? null)
+    setSelectedChatId(chat?.id ?? null)
+  }, [projects, view])
+
+  const selectedProject = React.useMemo(
+    () => projects.find((project) => project.id === selectedProjectId) ?? null,
+    [projects, selectedProjectId]
+  )
+  const selectedWorkspace = React.useMemo(
+    () =>
+      selectedProject?.workspaces.find(
+        (workspace) => workspace.id === selectedWorkspaceId
+      ) ?? null,
+    [selectedProject, selectedWorkspaceId]
+  )
+  const selectedChat = React.useMemo(
+    () =>
+      selectedWorkspace?.chats.find((chat) => chat.id === selectedChatId) ?? null,
+    [selectedWorkspace, selectedChatId]
+  )
+
+  const isProjectsView = view === "projects"
+  const isSettingsView = view === "settings"
+  const isProjectView = Boolean(
+    !isSettingsView &&
+      selectedProject &&
+      !selectedWorkspace &&
+      !selectedChat &&
+      !isProjectsView
+  )
+  const isWorkspaceView = Boolean(!isSettingsView && selectedWorkspace && !selectedChat)
+  const isChatView = Boolean(!isSettingsView && selectedChat)
+
+  const state = React.useMemo<WorkbenchState>(
+    () => ({
+      projects,
+      isLoading,
+      error,
+      view,
+      selectedProjectId,
+      selectedWorkspaceId,
+      selectedChatId,
+    }),
+    [
+      projects,
+      isLoading,
+      error,
+      view,
+      selectedProjectId,
+      selectedWorkspaceId,
+      selectedChatId,
+    ]
+  )
+
+  const actions = React.useMemo<WorkbenchActions>(
+    () => ({
+      reloadProjects,
+      updateProjects,
+      selectProjectsView,
+      selectSettingsView,
+      selectProject,
+      selectWorkspace,
+      selectChat,
+      setSelectedWorkspaceId,
+      setSelectedChatId,
+    }),
+    [
+      reloadProjects,
+      updateProjects,
+      selectProjectsView,
+      selectSettingsView,
+      selectProject,
+      selectWorkspace,
+      selectChat,
+    ]
+  )
+
+  const meta = React.useMemo<WorkbenchMeta>(
+    () => ({
+      isProjectsView,
+      isSettingsView,
+      isProjectView,
+      isWorkspaceView,
+      isChatView,
+      selectedProject,
+      selectedWorkspace,
+      selectedChat,
+    }),
+    [
+      isProjectsView,
+      isSettingsView,
+      isProjectView,
+      isWorkspaceView,
+      isChatView,
+      selectedProject,
+      selectedWorkspace,
+      selectedChat,
+    ]
+  )
+
+  return (
+    <WorkbenchContext.Provider value={{ state, actions, meta }}>
+      {children}
+    </WorkbenchContext.Provider>
+  )
+}
+
+export function useWorkbench() {
+  const context = React.useContext(WorkbenchContext)
+  if (!context) {
+    throw new Error("useWorkbench must be used within a WorkbenchProvider.")
+  }
+  return context
+}


### PR DESCRIPTION
## Summary
- Refactor the web workbench composition root so `App.tsx` mainly wires provider state, controller hooks, view-model hooks, and section components.
- Extract project/workspace/session CRUD and pull request orchestration into dedicated hooks, and split layout/overview/header/sidebar/chat/settings wiring into focused composable components.
- Update docs to reflect the new message-part mapping path and add a workbench architecture README; validated the refactor with `bun run --filter @maestro/web build`.