### PR TITLE
Prevent repeating identical incoming text

### DIFF
--- a/apps/cli/src/server.ts
+++ b/apps/cli/src/server.ts
@@ -178,7 +178,7 @@ const mergeMessagePart = (
     : "";
   if (incoming.type === "text" || incoming.type === "reasoning") {
     let nextText = existingText;
-    if (incomingText && incomingText.startsWith(existingText)) {
+    if (incomingText && existingText && incomingText.startsWith(existingText)) {
       nextText = incomingText;
     } else if (typeof delta === "string") {
       nextText = existingText + delta;

--- a/apps/web/src/lib/messages.test.ts
+++ b/apps/web/src/lib/messages.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  applyMessagePartUpdate,
+  createClientMessage,
+  type StructuredMessagePart,
+} from "./messages"
+
+describe("message part merge behavior", () => {
+  it("prefers delta over incoming text on first streamed chunk", () => {
+    const message = createClientMessage({
+      id: "assistant-1",
+      role: "assistant",
+      content: "",
+      parts: [],
+      isStreaming: true,
+    })
+
+    const updated = applyMessagePartUpdate(
+      message,
+      {
+        type: "text",
+        id: "part-1",
+        text: "start refactoring.start refactoring. be sure to leverage skills",
+      } as StructuredMessagePart,
+      "start refactoring."
+    )
+
+    expect(updated.content).toBe("start refactoring.")
+    expect(updated.parts).toMatchObject([
+      { type: "text", id: "part-1", text: "start refactoring." },
+    ])
+  })
+
+  it("keeps appending deltas when incoming text does not match existing prefix", () => {
+    const message = createClientMessage({
+      id: "assistant-1",
+      role: "assistant",
+      content: "Yes",
+      parts: [{ type: "text", id: "part-1", text: "Yes" }],
+      isStreaming: true,
+    })
+
+    const updated = applyMessagePartUpdate(
+      message,
+      {
+        type: "text",
+        id: "part-1",
+        text: "look at App.tsx - it has way too much logic, would you agree?Yes --",
+      } as StructuredMessagePart,
+      " --"
+    )
+
+    expect(updated.content).toBe("Yes --")
+    expect(updated.parts).toMatchObject([{ type: "text", id: "part-1", text: "Yes --" }])
+  })
+
+  it("accepts cumulative incoming text when it extends the same prefix", () => {
+    const message = createClientMessage({
+      id: "assistant-1",
+      role: "assistant",
+      content: "Yes",
+      parts: [{ type: "text", id: "part-1", text: "Yes" }],
+      isStreaming: true,
+    })
+
+    const updated = applyMessagePartUpdate(
+      message,
+      { type: "text", id: "part-1", text: "Yes -- apps/web/src/App.tsx" },
+      " -- apps/web/src/App.tsx"
+    )
+
+    expect(updated.content).toBe("Yes -- apps/web/src/App.tsx")
+    expect(updated.parts).toMatchObject([
+      { type: "text", id: "part-1", text: "Yes -- apps/web/src/App.tsx" },
+    ])
+  })
+})

--- a/apps/web/src/lib/messages.ts
+++ b/apps/web/src/lib/messages.ts
@@ -88,7 +88,7 @@ const mergeMessagePart = (
 
   if (incoming.type === "text" || incoming.type === "reasoning") {
     let nextText = existingText
-    if (incomingText && incomingText.startsWith(existingText)) {
+    if (incomingText && existingText && incomingText.startsWith(existingText)) {
       nextText = incomingText
     } else if (typeof delta === "string") {
       nextText = existingText + delta


### PR DESCRIPTION
Summary
- adjust the streaming merge logic so we only replace the existing text with the incoming payload when both are defined and the incoming text extends the current value
- add regression tests covering delta handling, prefix matching, and cumulative incoming text updates to guard against the echo bug

Testing
- Not run (not requested)